### PR TITLE
Fix layout requirements

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1685,19 +1685,20 @@ class experiment:
                 print(
                     "WARNING: No mask table found, and the cpu layout has not been set. At least one of these is requiret to set up the experiment if you're running MOM6 standalone with the FMS coupler. If you're running within CESM, ignore this message."
                 )
-            print(
-                f"No mask table found, but the cpu layout has been set to {self.layout} This suggests the domain is mostly water, so there are "
-                + "no `non compute` cells that are entirely land. If this doesn't seem right, "
-                + "ensure you've already run the `FRE_tools` method which sets up the cpu mask table. Keep an eye on any errors that might print while"
-                + "the FRE tools (which run C++ in the background) are running."
-            )
-            # Here we define a local copy of the layout just for use within this function.
-            # This prevents the layout from being overwritten in the main class in case
-            # in case the user accidentally loads in the wrong mask table.
-            layout = self.layout
-            ncpus = layout[0] * layout[1]
+            else:
+                print(
+                    f"No mask table found, but the cpu layout has been set to {self.layout} This suggests the domain is mostly water, so there are "
+                    + "no `non compute` cells that are entirely land. If this doesn't seem right, "
+                    + "ensure you've already run the `FRE_tools` method which sets up the cpu mask table. Keep an eye on any errors that might print while"
+                    + "the FRE tools (which run C++ in the background) are running."
+                )
+                # Here we define a local copy of the layout just for use within this function.
+                # This prevents the layout from being overwritten in the main class in case
+                # in case the user accidentally loads in the wrong mask table.
+                layout = self.layout
+                ncpus = layout[0] * layout[1]
 
-        print("Number of CPUs required: ", ncpus)
+                print("Number of CPUs required: ", ncpus)
 
         ## Modify the MOM_layout file to have correct horizontal dimensions and CPU layout
         # TODO Re-implement with package that works for this file type? or at least tidy up code
@@ -1734,7 +1735,8 @@ class experiment:
         ## If using payu to run the model, create a payu configuration file
         if not using_payu and os.path.exists(f"{self.mom_run_dir}/config.yaml"):
             os.remove(f"{self.mom_run_dir}/config.yaml")
-
+        elif ncpus == None:
+            print("WARNING: Layout has not been set! Cannot create payu configuration file. Run the FRE_tools first.")
         else:
             with open(f"{self.mom_run_dir}/config.yaml", "r") as file:
                 lines = file.readlines()

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1679,11 +1679,15 @@ class experiment:
             print(
                 f"Mask table {p.name} read. Using this to infer the cpu layout {layout}, total masked out cells {masked}, and total number of CPUs {ncpus}."
             )
-
+        # Case where there's no mask table. Either because user hasn't run FRE tools, or because the domain is mostly water.
         if mask_table == None:
-            if self.layout == None:
+            # Here we define a local copy of the layout just for use within this function.
+            # This prevents the layout from being overwritten in the main class in case
+            # in case the user accidentally loads in the wrong mask table.
+            layout = self.layout
+            if layout == None:
                 print(
-                    "WARNING: No mask table found, and the cpu layout has not been set. At least one of these is requiret to set up the experiment if you're running MOM6 standalone with the FMS coupler. If you're running within CESM, ignore this message."
+                    "WARNING: No mask table found, and the cpu layout has not been set. \nAt least one of these is requiret to set up the experiment if you're running MOM6 standalone with the FMS coupler. \nIf you're running within CESM, ignore this message."
                 )
             else:
                 print(
@@ -1692,12 +1696,9 @@ class experiment:
                     + "ensure you've already run the `FRE_tools` method which sets up the cpu mask table. Keep an eye on any errors that might print while"
                     + "the FRE tools (which run C++ in the background) are running."
                 )
-                # Here we define a local copy of the layout just for use within this function.
-                # This prevents the layout from being overwritten in the main class in case
-                # in case the user accidentally loads in the wrong mask table.
-                layout = self.layout
-                ncpus = layout[0] * layout[1]
 
+
+                ncpus = layout[0] * layout[1]
                 print("Number of CPUs required: ", ncpus)
 
         ## Modify the MOM_layout file to have correct horizontal dimensions and CPU layout
@@ -1710,7 +1711,7 @@ class experiment:
                         lines[jj] = f'MASKTABLE = "{mask_table}"\n'
                     else:
                         lines[jj] = "# MASKTABLE = no mask table"
-                if "LAYOUT =" in lines[jj] and "IO" not in lines[jj]:
+                if "LAYOUT =" in lines[jj] and "IO" not in lines[jj] and layout != None:
                     lines[jj] = f"LAYOUT = {layout[1]},{layout[0]}\n"
 
                 if "NIGLOBAL" in lines[jj]:


### PR DESCRIPTION
There were some unintended consequences of allowing layout to be unset. This has now been handled, so users no longer have to run the FRE tools. A warning is printed, which says that if you're a CESM user you can ignore 