### PR TITLE
Replace minimum layers with min depth

### DIFF
--- a/demos/reanalysis-forced.ipynb
+++ b/demos/reanalysis-forced.ipynb
@@ -135,6 +135,7 @@
     "    number_vertical_layers = 75,\n",
     "    layer_thickness_ratio = 10,\n",
     "    depth = 4500,\n",
+    "    minimum_depth = 5,\n",
     "    mom_run_dir = run_dir,\n",
     "    mom_input_dir = input_dir,\n",
     "    toolpath_dir = toolpath_dir\n",
@@ -217,7 +218,6 @@
     "    longitude_coordinate_name='lon',\n",
     "    latitude_coordinate_name='lat',\n",
     "    vertical_coordinate_name='elevation',\n",
-    "    minimum_layers=1\n",
     "    )"
    ]
   },

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -461,7 +461,7 @@ class experiment:
         grid_type="even_spacing",
         repeat_year_forcing=False,
         read_existing_grids=False,
-        minimum_depth = 4
+        minimum_depth=4,
     ):
         ## in case list was given, convert to tuples
         self.longitude_extent = tuple(longitude_extent)
@@ -487,7 +487,9 @@ class experiment:
         self.repeat_year_forcing = repeat_year_forcing
         self.ocean_mask = None
         self.layout = None  # This should be a tuple. Leaving in a dummy 'None' makes it easy to remind the user to provide a value later on.
-        self.min_depth = minimum_depth  # Minimum depth. Shallower water will be masked out. 
+        self.min_depth = (
+            minimum_depth  # Minimum depth. Shallower water will be masked out.
+        )
         if read_existing_grids:
             try:
                 self.hgrid = xr.open_dataset(self.mom_input_dir / "hgrid.nc")
@@ -1306,9 +1308,7 @@ class experiment:
 
         self.tidy_bathymetry(fill_channels, positive_down)
 
-    def tidy_bathymetry(
-        self, fill_channels=False, positive_down=True
-    ):
+    def tidy_bathymetry(self, fill_channels=False, positive_down=True):
         """
         An auxiliary function for bathymetry used to fix up the metadata and remove inland
         lakes after regridding the bathymetry. Having `tidy_bathymetry` as a separate
@@ -1688,7 +1688,6 @@ class experiment:
                     + "the FRE tools (which run C++ in the background) are running."
                 )
 
-
                 ncpus = layout[0] * layout[1]
                 print("Number of CPUs required: ", ncpus)
 
@@ -1728,7 +1727,9 @@ class experiment:
         if not using_payu and os.path.exists(f"{self.mom_run_dir}/config.yaml"):
             os.remove(f"{self.mom_run_dir}/config.yaml")
         elif ncpus == None:
-            print("WARNING: Layout has not been set! Cannot create payu configuration file. Run the FRE_tools first.")
+            print(
+                "WARNING: Layout has not been set! Cannot create payu configuration file. Run the FRE_tools first."
+            )
         else:
             with open(f"{self.mom_run_dir}/config.yaml", "r") as file:
                 lines = file.readlines()

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -93,7 +93,6 @@ def test_setup_bathymetry(
         longitude_coordinate_name="silly_lon",
         latitude_coordinate_name="silly_lat",
         vertical_coordinate_name="silly_depth",
-        minimum_layers=1,
         chunks={"longitude": 10, "latitude": 10},
     )
 


### PR DESCRIPTION
Currently, a user has to specify min layers rather than simply a minimum depth. This is not intuitive! Now user specifies the min depth directly. This is specified at the experiment level now, and read later by the bathymetry.