### PR TITLE
Various bathymetry improvements / bugfixes

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2771,8 +2771,13 @@ class segment:
     ):
         ## Store coordinate names
         if arakawa_grid == "A" and infile is not None:
-            self.x = varnames["x"]
-            self.y = varnames["y"]
+            try:
+                self.x = varnames["x"]
+                self.y = varnames["y"]
+            ## In case user continues using T point names for A grid
+            except:                         
+                self.x = varnames["xh"]
+                self.y = varnames["yh"]  
 
         elif arakawa_grid in ("B", "C"):
             self.xq = varnames["xq"]

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2775,9 +2775,9 @@ class segment:
                 self.x = varnames["x"]
                 self.y = varnames["y"]
             ## In case user continues using T point names for A grid
-            except:                         
+            except:
                 self.x = varnames["xh"]
-                self.y = varnames["yh"]  
+                self.y = varnames["yh"]
 
         elif arakawa_grid in ("B", "C"):
             self.xq = varnames["xq"]

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -92,9 +92,7 @@ def test_setup_bathymetry(
         bathymetry_path=str(bathymetry_file),
         longitude_coordinate_name="silly_lon",
         latitude_coordinate_name="silly_lat",
-        vertical_coordinate_name="silly_depth",
-        chunks={"longitude": 10, "latitude": 10},
-    )
+        vertical_coordinate_name="silly_depth"    )
 
     bathymetry_file.unlink()
 

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -92,7 +92,8 @@ def test_setup_bathymetry(
         bathymetry_path=str(bathymetry_file),
         longitude_coordinate_name="silly_lon",
         latitude_coordinate_name="silly_lat",
-        vertical_coordinate_name="silly_depth"    )
+        vertical_coordinate_name="silly_depth",
+    )
 
     bathymetry_file.unlink()
 


### PR DESCRIPTION
Bathymetry was attempting to regrid in parallel despite this not being efficient for our use case. Parallel xesmf regrid is only useful if the destination grid doesn't fit in memory. By extension, it makes no sense if the destination grid is smaller in size than the base grid (GEBCO), as the latter always has to be read into memory for each chunk. 

Bathymetry now always done in serial. Also fixed the land mask issue. Closes #10 