### PR TITLE
allow __getattr__ to read in data arrays from disk

### DIFF
--- a/demos/reanalysis-forced.ipynb
+++ b/demos/reanalysis-forced.ipynb
@@ -225,7 +225,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Check out your domain:"
+    "### Check out your domain!\n",
+    "\n",
+    "Calling `expt.bathymetry` returns an xarray dataset, which can be plotted as usual. If you haven't yet run setup_bathymetry, calling `expt.bathymetry` will return `None` and prompt you to do so!"
    ]
   },
   {
@@ -307,6 +309,38 @@
     "        boundaries = [\"south\", \"north\", \"west\", \"east\"],\n",
     "        arakawa_grid = \"A\"\n",
     "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check out your initial condition data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expt.init_tracers.salt.isel(zl = 0).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### You can plot your segment data too"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expt.segment_001.u_segment_001.isel(time = 5).plot()"
    ]
   },
   {

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -14,7 +14,7 @@ import shutil
 import os
 import importlib.resources
 import datetime
-from .utils import quadrilateral_areas, ap2ep, ep2ap, DataReader
+from .utils import quadrilateral_areas, ap2ep, ep2ap
 import pandas as pd
 from pathlib import Path
 import glob

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1114,7 +1114,6 @@ class experiment:
             "minimum_depth": self.minimum_depth,
             "vgrid": str(vgrid_path),
             "hgrid": str(hgrid_path),
-            "bathymetry": DSHolder(self.mom_input_dir, "bathymetry"),
             "ocean_state": self.ocean_state_boundaries,
             "tides": self.tides_boundaries,
             "initial_conditions": self.initial_condition,

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -18,9 +18,9 @@ from .utils import (
     quadrilateral_areas,
     ap2ep,
     ep2ap,
+    DataReader
 )
 import pandas as pd
-import re
 from pathlib import Path
 import glob
 from collections import defaultdict
@@ -585,6 +585,7 @@ def generate_rectangular_hgrid(lons, lats):
         }
     )
 
+        
 
 class experiment:
     """The main class for setting up a regional experiment.
@@ -697,7 +698,7 @@ class experiment:
         depth,
         mom_run_dir,
         mom_input_dir,
-        toolpath_dir,
+        toolpath_dir = None,
         longitude_extent=None,
         latitude_extent=None,
         hgrid_type="even_spacing",
@@ -793,6 +794,7 @@ class experiment:
         input_rundir = self.mom_input_dir / "rundir"
         if not input_rundir.exists():
             input_rundir.symlink_to(self.mom_run_dir.resolve())
+
 
     def __str__(self) -> str:
         return json.dumps(self.write_config_file(export=False, quiet=True), indent=4)
@@ -1065,7 +1067,7 @@ class experiment:
             "minimum_depth": self.minimum_depth,
             "vgrid": str(vgrid_path),
             "hgrid": str(hgrid_path),
-            "bathymetry": self.bathymetry_property,
+            "bathymetry": DSHolder(self.mom_input_dir, "bathymetry"),
             "ocean_state": self.ocean_state_boundaries,
             "tides": self.tides_boundaries,
             "initial_conditions": self.initial_condition,
@@ -1847,7 +1849,7 @@ class experiment:
         tgrid = xr.Dataset(
             data_vars={
                 "depth": (
-                    ["nx", "ny"],
+                    ["ny", "nx"],
                     np.zeros(
                         self.hgrid.x.isel(
                             nxp=slice(1, None, 2), nyp=slice(1, None, 2)
@@ -1857,13 +1859,13 @@ class experiment:
             },
             coords={
                 "lon": (
-                    ["nx", "ny"],
+                    ["ny", "nx"],
                     self.hgrid.x.isel(
                         nxp=slice(1, None, 2), nyp=slice(1, None, 2)
                     ).values,
                 ),
                 "lat": (
-                    ["nx", "ny"],
+                    ["ny", "nx"],
                     self.hgrid.y.isel(
                         nxp=slice(1, None, 2), nyp=slice(1, None, 2)
                     ).values,

--- a/regional_mom6/utils.py
+++ b/regional_mom6/utils.py
@@ -1,40 +1,5 @@
 import numpy as np
-import pathlib.Path as Path
-import xarray as xr
-class DataReader:
-    """
-    Internally used class to hold the datasets associated with each input file. Allows user to return dataset, get the path, or plot
-    each input file via a simple command like `expt.bathymetry.plot` or `expt.bathymetry.path`.
-    """
-    def __init__(self,path, name):
-        ## Note, if including plot functions later, add plot_function = None as a kwarg
-        self.name = name
-        self.path = Path(path)
-        self.dataset = None
-        self()
-    def __call__(self):
-        if self.dataset is not None:
-            return self.dataset
-        try:
-            if "segment" in self.name:
-                self.dataset = xr.open_mfdataset(str(self.path / f"*{self.name}*.nc"), decode_cf=False, decode_times=False)
-            else:
-                self.dataset = xr.open_dataset(self.path / f"{self.name}.nc", decode_cf=False, decode_times=False)
-            return self.dataset
 
-        except FileNotFoundError:
-            if self.name == "bathymetry":
-                method = "setup_bathymetry"
-            elif self.name == "init_vel":
-                method = "setup_initial_conditions"
-            else:
-                method = "appropriate"
-            
-            print(f"{self.name}.nc file not found! Make sure you've successfully run the {method} method, or copied your own {self.name} file into {self.path}.")
-        return None
-    
-    def __repr__(self):
-        return repr(self())
 
 def vecdot(v1, v2):
     """Return the dot product of vectors ``v1`` and ``v2``.

--- a/regional_mom6/utils.py
+++ b/regional_mom6/utils.py
@@ -1,5 +1,40 @@
 import numpy as np
+import pathlib.Path as Path
+import xarray as xr
+class DataReader:
+    """
+    Internally used class to hold the datasets associated with each input file. Allows user to return dataset, get the path, or plot
+    each input file via a simple command like `expt.bathymetry.plot` or `expt.bathymetry.path`.
+    """
+    def __init__(self,path, name):
+        ## Note, if including plot functions later, add plot_function = None as a kwarg
+        self.name = name
+        self.path = Path(path)
+        self.dataset = None
+        self()
+    def __call__(self):
+        if self.dataset is not None:
+            return self.dataset
+        try:
+            if "segment" in self.name:
+                self.dataset = xr.open_mfdataset(str(self.path / f"*{self.name}*.nc"), decode_cf=False, decode_times=False)
+            else:
+                self.dataset = xr.open_dataset(self.path / f"{self.name}.nc", decode_cf=False, decode_times=False)
+            return self.dataset
 
+        except FileNotFoundError:
+            if self.name == "bathymetry":
+                method = "setup_bathymetry"
+            elif self.name == "init_vel":
+                method = "setup_initial_conditions"
+            else:
+                method = "appropriate"
+            
+            print(f"{self.name}.nc file not found! Make sure you've successfully run the {method} method, or copied your own {self.name} file into {self.path}.")
+        return None
+    
+    def __repr__(self):
+        return repr(self())
 
 def vecdot(v1, v2):
     """Return the dot product of vectors ``v1`` and ``v2``.


### PR DESCRIPTION
This PR adds some extra lines to `__getattr__` which check whether an attribute is actually data, like `bathymetry`, `init_velocities` etc. In this case, it returns the appropriate dataarray after reading from disk. If not, prints the usual error message, listing available attributes.