### PR TITLE
Minor changes ahead of CrocoDash-visualCaseGen integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
   "xarray <= 2024.7.0",
   "xesmf >= 0.8.4",
   "f90nml >= 1.4.1",
+  "aiohttp >= 3.9.5,<3.10.0",
+  "copernicusmarine >= 1.2.4,<1.3.0"
 ]
 
 [build-system]

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -719,7 +719,9 @@ class experiment:
                 raise ValueError
         else:
             if hgrid_path:
-                raise ValueError("hgrid_path can only be set if hgrid_type is 'from_file'.")
+                raise ValueError(
+                    "hgrid_path can only be set if hgrid_type is 'from_file'."
+                )
             self.longitude_extent = tuple(longitude_extent)
             self.latitude_extent = tuple(latitude_extent)
             self.hgrid = self._make_hgrid()
@@ -742,7 +744,9 @@ class experiment:
             self.vgrid = self._make_vgrid(vgrid_from_file.dz.data)
         else:
             if vgrid_path:
-                raise ValueError("vgrid_path can only be set if vgrid_type is 'from_file'.")
+                raise ValueError(
+                    "vgrid_path can only be set if vgrid_type is 'from_file'."
+                )
             self.vgrid = self._make_vgrid()
 
         self.segments = {}
@@ -1885,7 +1889,9 @@ class experiment:
         bathymetry_output.depth.attrs["coordinates"] = "lon lat"
         if write_to_file:
             bathymetry_output.to_netcdf(
-                self.mom_input_dir / "bathymetry_original.nc", mode="w", engine="netcdf4"
+                self.mom_input_dir / "bathymetry_original.nc",
+                mode="w",
+                engine="netcdf4",
             )
 
         tgrid = xr.Dataset(
@@ -1924,7 +1930,9 @@ class experiment:
         tgrid.depth.attrs["coordinates"] = "lon lat"
         if write_to_file:
             tgrid.to_netcdf(
-                self.mom_input_dir / "bathymetry_unfinished.nc", mode="w", engine="netcdf4"
+                self.mom_input_dir / "bathymetry_unfinished.nc",
+                mode="w",
+                engine="netcdf4",
             )
             tgrid.close()
 
@@ -1945,7 +1953,9 @@ class experiment:
         bathymetry = regridder(bathymetry_output)
         if write_to_file:
             bathymetry.to_netcdf(
-                self.mom_input_dir / "bathymetry_unfinished.nc", mode="w", engine="netcdf4"
+                self.mom_input_dir / "bathymetry_unfinished.nc",
+                mode="w",
+                engine="netcdf4",
             )
         print(
             "Regridding successful! Now calling `tidy_bathymetry` method for some finishing touches..."
@@ -1957,7 +1967,11 @@ class experiment:
         return bathymetry
 
     def tidy_bathymetry(
-        self, fill_channels=False, positive_down=False, vertical_coordinate_name="depth", bathymetry=None
+        self,
+        fill_channels=False,
+        positive_down=False,
+        vertical_coordinate_name="depth",
+        bathymetry=None,
     ):
         """
         An auxiliary function for bathymetry used to fix up the metadata and remove inland


### PR DESCRIPTION
Minor changes to facilitate CrocoDash-visualCaseGen integration. Note that these changes do not mean an integration of visualCaseGen into regional-mom6. All CESM-specific features remain within CrocoDash and visualCaseGen.

 - Adds aiohttp and copernicusmarine dependencies. These are used in demos, so should be included in the environment.
 - In classmethods, `cls` should be the first arg instead of `self`.
 - introduce optional write_to_file arg in setup_bathymetry.
 - introduce optional bathymetry obj arg in tidy_bathymetry.
 - add hgrid_path and vgrid_path args to __init__ to allow non-standard filenames. Similarly, add thickesses arg to _make_vgrid.