### PR TITLE
Change default rotation behaviour

### DIFF
--- a/docs/angle_calculation.md
+++ b/docs/angle_calculation.md
@@ -20,7 +20,7 @@ Steps 1-5 replicate the angle calculation as done by MOM6. Step 6 is an addition
     3. Thus, given the same units, we can call arctan to get the angle in degrees
 
 6. **Additional step to apply to boundaries**
-Since the boundaries in a regional MOM6 model are on the q rather than t points, we need to expand the grid and calculate the angle at the boundary points. This is implemented in the `create_expanded_hgrid` function.
+Since the boundaries for a regional MOM6 domain are on the `q` points and not on the `t` points, to calculate the angle at the boundary points we need to expand the grid. This is implemented in the `create_expanded_hgrid` method.
 
 ## Convert this method to boundary angles - 3 Options
 1. **GIVEN_ANGLE**: Don't calculate the angle and use the user-provided field in the hgrid called "angle_dx"

--- a/docs/angle_calculation.md
+++ b/docs/angle_calculation.md
@@ -8,7 +8,7 @@ Here we explain the implementation of MOM6 angle calculation in regional-mom6, w
 
 
 ## Boundary rotation algorithm
-Steps 1-5 are the same as MOM6's internal angle calculation. Step 6 is an additional step required to apply this algorithm to the boundaries
+Steps 1-5 replicate the angle calculation as done by MOM6. Step 6 is an additional step required to apply this algorithm to the boundary points.
 
 1. Calculate pi/4rads / 180 degrees  = Gives a 1/4 conversion of degrees to radians. I.E. multiplying an angle in degrees by this gives the conversion to radians at 1/4 the value. 
 2. Figure out the longitudunal extent of our domain, or periodic range of longitudes. For global cases it is len_lon = 360, for our regional cases it is given by the hgrid.

--- a/docs/angle_calculation.md
+++ b/docs/angle_calculation.md
@@ -22,7 +22,7 @@ Steps 1-5 replicate the angle calculation as done by MOM6. Step 6 is an addition
 6. **Additional step to apply to boundaries**
 Since the boundaries for a regional MOM6 domain are on the `q` points and not on the `t` points, to calculate the angle at the boundary points we need to expand the grid. This is implemented in the `create_expanded_hgrid` method.
 
-## Convert this method to boundary angles - 3 Options
+## Convert this method to boundary angles - 2 Options
 1. **GIVEN_ANGLE**: Don't calculate the angle and use the user-provided field in the hgrid called "angle_dx"
 2. **EXPAND_GRID**: Calculate another boundary row/column points around the hgrid using simple difference techniques. Use the new points to calculate the angle at the boundaries. This works because we can now access the four points needed to calculate the angle, where previously at boundaries we would be missing at least two. 
 

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1138,7 +1138,7 @@ class experiment:
         varnames,
         arakawa_grid="A",
         vcoord_type="height",
-        rotational_method=rot.RotationMethod.GIVEN_ANGLE,
+        rotational_method=rot.RotationMethod.EXPAND_GRID,
     ):
         """
         Reads the initial condition from files in ``ic_path``, interpolates to the
@@ -1577,7 +1577,7 @@ class experiment:
         arakawa_grid="A",
         boundary_type="rectangular",
         bathymetry_path=None,
-        rotational_method=rot.RotationMethod.GIVEN_ANGLE,
+        rotational_method=rot.RotationMethod.EXPAND_GRID,
     ):
         """
         This is a wrapper for :func:`~simple_boundary`. Given a list of up to four cardinal directions,
@@ -1596,7 +1596,7 @@ class experiment:
                 is supported.
             bathymetry_path (Optional[str]): Path to the bathymetry file. Default is ``None``, in which case the
                 boundary condition is not masked.
-            rotational_method (Optional[str]): Method to use for rotating the boundary velocities. Default is ``GIVEN_ANGLE``.
+            rotational_method (Optional[str]): Method to use for rotating the boundary velocities. Default is ``EXPAND_GRID``.
         """
         if not (boundary_type == "rectangular" or boundary_type == "curvilinear"):
             raise ValueError(
@@ -1640,7 +1640,7 @@ class experiment:
         segment_number,
         arakawa_grid="A",
         bathymetry_path=None,
-        rotational_method=rot.RotationMethod.GIVEN_ANGLE,
+        rotational_method=rot.RotationMethod.EXPAND_GRID,
     ):
         """
         Set up a boundary forcing file for a given ``orientation``.
@@ -1661,7 +1661,7 @@ class experiment:
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case
                 the boundary condition is not masked.
             rotational_method (Optional[str]): Method to use for rotating the boundary velocities.
-                Default is 'GIVEN_ANGLE'.
+                Default is 'EXPAND_GRID'.
         """
 
         print(
@@ -1698,7 +1698,7 @@ class experiment:
         tidal_constituents=None,
         boundary_type="rectangular",
         bathymetry_path=None,
-        rotational_method=rot.RotationMethod.GIVEN_ANGLE,
+        rotational_method=rot.RotationMethod.EXPAND_GRID,
     ):
         """Subset the tidal data and generate more boundary files.
 
@@ -1710,7 +1710,7 @@ class experiment:
             boundary_type (str): Type of boundary. Currently, only rectangle and curvilinear grids are supported.
                 Here, rectangle refers to grids with boundaries that are parallel to lines of constant longitude or latitude.
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case the boundary condition is not masked
-            rotational_method (str): Method to use for rotating the tidal velocities. Default is 'GIVEN_ANGLE'.
+            rotational_method (str): Method to use for rotating the tidal velocities. Default is 'EXPAND_GRID'.
 
         Returns:
             netCDF files: Regridded tidal velocity and elevation files in 'inputdir/forcing'
@@ -3003,12 +3003,12 @@ class segment:
         self.segment_name = segment_name
         self.repeat_year_forcing = repeat_year_forcing
 
-    def regrid_velocity_tracers(self, rotational_method=rot.RotationMethod.GIVEN_ANGLE):
+    def regrid_velocity_tracers(self, rotational_method=rot.RotationMethod.EXPAND_GRID):
         """
         Cut out and interpolate the velocities and tracers.
 
         Arguments:
-            rotational_method (rot.RotationMethod): The method to use for rotation of the velocities. Currently, the default method, ``GIVEN_ANGLE``, works even with non-rotated grids.
+            rotational_method (rot.RotationMethod): The method to use for rotation of the velocities. Currently, the default method, ``EXPAND_GRID``, works even with non-rotated grids.
         """
 
         rawseg = xr.open_dataset(self.infile, decode_times=False, engine="netcdf4")
@@ -3264,7 +3264,7 @@ class segment:
         tpxo_u,
         tpxo_h,
         times,
-        rotational_method=rot.RotationMethod.GIVEN_ANGLE,
+        rotational_method=rot.RotationMethod.EXPAND_GRID,
     ):
         """
         Regrids and interpolates the tidal data for MOM6. Steps include:
@@ -3292,7 +3292,7 @@ class segment:
             infile_td (str): Raw Tidal File/Dir
             tpxo_v, tpxo_u, tpxo_h (xarray.Dataset): Specific adjusted for MOM6 tpxo datasets (Adjusted with :func:`~setup_tides`)
             times (pd.DateRange): The start date of our model period
-            rotational_method (rot.RotationMethod): The method to use for rotation of the velocities. Currently, the default method, GIVEN_ANGLE, works even with non-rotated grids.
+            rotational_method (rot.RotationMethod): The method to use for rotation of the velocities. Currently, the default method, EXPAND_GRID, works even with non-rotated grids.
 
         Returns:
             netCDF files: Regridded tidal velocity and elevation files in 'inputdir/forcing'

--- a/regional_mom6/rotation.py
+++ b/regional_mom6/rotation.py
@@ -55,7 +55,7 @@ def initialize_grid_rotation_angles_using_expanded_hgrid(
 
 def initialize_grid_rotation_angle(hgrid: xr.Dataset) -> xr.DataArray:
     """
-    Calculate the ``angle_dx`` in degrees from the true x direction (parallel to latitude) counter-clockwise and return as a dataarray.
+    Calculate the ``angle_dx`` in degrees from the true x direction (parallel to latitude) counter-clockwise and return as a dataarray. (Mimics MOM6 angle calculation function :func:`~initialize_grid_rotation_angle`)
 
     Parameters
     ----------
@@ -132,6 +132,8 @@ def mom6_angle_calculation_method(
     """
     Calculate the angle of the point using the MOM6 method in :func:`~initialize_grid_rotation_angle`.
     This method can handle vectorized computations.
+
+    (Adapted from MOM6 code; https://github.com/mom-ocean/MOM6/blob/e818ea4e792f0b85797247f955789b3c1210db8d/src/initialization/MOM_shared_initialization.F90#L535)
 
     Parameters
     ----------


### PR DESCRIPTION
Changes default behaviour to calculate angles internally rather than using user provided angle which may be inconsistent with mom6. As per discussion in https://github.com/COSIMA/regional-mom6/pull/193