### PR TITLE
Fix Indexing Bug?

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -3225,13 +3225,13 @@ class segment:
         )
 
         # Overwrite the actual lat/lon values in the dimensions, replace with incrementing integers
-        segment_out[f"{coords.attrs['parallel']}_{self.segment_name}"] = np.arange(
-            segment_out[f"{coords.attrs['parallel']}_{self.segment_name}"].size
-        )
-        segment_out[f"{coords.attrs['parallel']}_{self.segment_name}"] = np.arange(
-            segment_out[f"{coords.attrs['parallel']}_{self.segment_name}"].size
-        )
+
         segment_out[f"{coords.attrs['perpendicular']}_{self.segment_name}"] = [0]
+
+        segment_out[f"{coords.attrs['parallel']}_{self.segment_name}"] = np.arange(
+            segment_out[f"{coords.attrs['parallel']}_{self.segment_name}"].size
+        )
+
         encoding_dict = {
             "time": {"dtype": "double"},
             f"nx_{self.segment_name}": {


### PR DESCRIPTION
For some reason, in the new CrocoDash environment, the indexing doesn't work if the perpendicular segment is assigned after the parallel segment. I couldn't figure out why, but switching the order works just fine. Let me know if this is okay!