### PR TITLE
Fix input time units

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,6 +28,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Fix git stuff
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git config --global --add safe.directory '*'
       - name: Set up Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1502,16 +1502,20 @@ class experiment:
         if bgc_tracer_names is None:
             bgc_tracer_names = {}
 
+        # In the future, we should change varnames to physical_varnames
+        physical_varnames = varnames
+        all_varnames = physical_varnames.copy()
+
         # Merge the bgc tracer names into the varnames
         if bgc_tracer_names:
-            key = "tracers" if "tracers" in varnames else "tracer_var_names"
-            varnames[key] = {**varnames[key], **bgc_tracer_names}
+            key = "tracers" if "tracers" in physical_varnames else "tracer_var_names"
+            all_varnames[key] = {**physical_varnames[key], **bgc_tracer_names}
 
         # Now iterate through our four boundaries
         for orientation in self.boundaries:
             self.setup_single_boundary(
                 Path(raw_boundaries_path / (orientation + "_unprocessed.nc")),
-                varnames,
+                all_varnames,
                 orientation,  # The cardinal direction of the boundary
                 self.find_MOM6_rectangular_orientation(
                     orientation

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1305,7 +1305,10 @@ class experiment:
             },
         )
 
-        encoding = {var: {"_FillValue": -1e20, "missing_value": -1e20} for var in reprocessed_var_map["tracer_var_names"].keys()}
+        encoding = {
+            var: {"_FillValue": -1e20, "missing_value": -1e20}
+            for var in reprocessed_var_map["tracer_var_names"].keys()
+        }
         breakpoint()
         tracers_out.to_netcdf(
             self.mom_input_dir / "init_tracers.nc",
@@ -3343,7 +3346,9 @@ def apply_arakawa_grid_mapping(var_mapping: dict, arakawa_grid: str = None) -> d
             "eta_var_name": var_mapping["eta"],
             "time_var_name": var_mapping["time"],
             "depth_coord": var_mapping["zl"],
-            "tracer_var_names": var_mapping["tracers"] # validate_var_mapping will ensure this is a nested dict with "salt" and "temp" keys
+            "tracer_var_names": var_mapping[
+                "tracers"
+            ],  # validate_var_mapping will ensure this is a nested dict with "salt" and "temp" keys
         }
 
         if arakawa_grid == "A":

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1305,13 +1305,12 @@ class experiment:
             },
         )
 
+        encoding = {var: {"_FillValue": -1e20, "missing_value": -1e20} for var in reprocessed_var_map["tracer_var_names"].keys()}
+        breakpoint()
         tracers_out.to_netcdf(
             self.mom_input_dir / "init_tracers.nc",
             mode="w",
-            encoding={
-                "temp": {"_FillValue": -1e20, "missing_value": -1e20},
-                "salt": {"_FillValue": -1e20, "missing_value": -1e20},
-            },
+            encoding=encoding,
         )
         eta_out.to_netcdf(
             self.mom_input_dir / "init_eta.nc",
@@ -1334,11 +1333,8 @@ class experiment:
         )
         validate_general_file(
             tracers_out,
-            ["temp", "salt"],
-            {
-                "temp": {"_FillValue": -1e20, "missing_value": -1e20},
-                "salt": {"_FillValue": -1e20, "missing_value": -1e20},
-            },
+            list(reprocessed_var_map["tracer_var_names"].keys()),
+            encoding,
         )
         validate_general_file(
             vel_out,

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import dask.array as da
 import xarray as xr
@@ -1450,6 +1452,7 @@ class experiment:
         self,
         raw_boundaries_path,
         varnames,
+        bgc_tracer_names: dict = None,
         arakawa_grid="A",
         bathymetry_path=None,
         rotational_method=rot.RotationMethod.EXPAND_GRID,
@@ -1465,6 +1468,8 @@ class experiment:
             raw_boundaries_path (str): Path to the directory containing the raw boundary forcing files.
             varnames (Dict[str, str]): Mapping from MOM6 variable/coordinate names to the name in the
                 input dataset.
+            bgc_tracer_names (Dict[str, str]): Specify the BGC tracer names to the name in the
+                input dataset, can also be specified in the varnames dict but this is here so we can reformat the output into seperate files. For example, ``{'oxygen': 'o2', 'phosphate': 'po4', ...}``.
             boundaries (List[str]): List of cardinal directions for which to create boundary forcing files.
                 Default is ``["south", "north", "west", "east"]``.
             arakawa_grid (Optional[str]): Arakawa grid staggering type of the boundary forcing.
@@ -1496,6 +1501,14 @@ class experiment:
                 "This method only supports up to four boundaries. To set up more complex boundary shapes you can manually call the 'simple_boundary' method for each boundary."
             )
 
+        if bgc_tracer_names is None:
+            bgc_tracer_names = {}
+
+        # Merge the bgc tracer names into the varnames
+        if bgc_tracer_names:
+            key = "tracers" if "tracers" in varnames else "tracer_var_names"
+            varnames[key] = {**varnames[key], **bgc_tracer_names}
+
         # Now iterate through our four boundaries
         for orientation in self.boundaries:
             self.setup_single_boundary(
@@ -1511,6 +1524,43 @@ class experiment:
                 regridding_method=regridding_method,
                 fill_method=fill_method,
             )
+
+        # Scrape the bgc var names into their own files for the boundary conditions (required for generic tracers at the moment, Apr 2026)
+        self.reformat_bgc_tracers_into_files(bgc_tracer_names)
+
+    def reformat_bgc_tracers_into_files(self, bgc_tracer_names: dict = None):
+        """
+        Reformat the boundary condition files so that the BGC tracers are in separate files from the physical tracers. This is required for generic tracers at the moment (Apr 2026) but may not be in the future as we add more flexibility to the code.
+
+        Arguments:
+            bgc_tracer_names (Dict[str, str]): Specify the BGC tracer names to the name in the
+                input dataset, can also be specified in the varnames dict but this is here so we can reformat the output into seperate files. For example, ``{'oxygen': 'o2', 'phosphate': 'po4', ...}``.
+        """
+
+        if bgc_tracer_names is None:
+            bgc_tracer_names = {}
+
+        # Read in the forcing datasets
+        datasets = {}
+        for boundary in self.boundaries:
+            num = str(self.find_MOM6_rectangular_orientation(boundary)).zfill(3)
+            datasets[num] = xr.open_mfdataset(
+                self.mom_input_dir / f"forcing_obc_segment_{num}.nc"
+            )
+
+        # Get base variable names
+        base_vars = list(bgc_tracer_names.keys())
+        for var in base_vars:
+            ds_var = xr.Dataset()
+            for key, ds in datasets.items():
+                var_name = f"{var}_segment_{key}"  # 001, 002, 003, 004
+                ds_var[var_name] = ds[var_name]
+                dz_var_name = f"dz_{var_name}"
+                if dz_var_name in ds:
+                    ds_var[dz_var_name] = ds[dz_var_name]
+            output_file = self.mom_input_dir / f"{var}_obc_segment.nc"
+            ds_var.to_netcdf(output_file, unlimited_dims="time")
+            print("Saved BGC tracer {} to file {}".format(var, output_file))
 
     def setup_single_boundary(
         self,

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -3480,7 +3480,7 @@ def identify_arakawa_grid(var_mapping):
     elif (
         var_mapping["v_x_coord"] != var_mapping["u_x_coord"]
         and var_mapping["u_x_coord"] != var_mapping["tracer_x_coord"]
-        and var_mapping["v_x_coord"] != var_mapping["tracer_x_coord"]
+        and var_mapping["v_y_coord"] != var_mapping["tracer_y_coord"]
     ):
         return "C"
     else:

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1535,7 +1535,7 @@ class experiment:
                 input dataset, can also be specified in the varnames dict but this is here so we can reformat the output into seperate files. For example, ``{'oxygen': 'o2', 'phosphate': 'po4', ...}``.
         """
 
-        if bgc_tracer_names is None:
+        if bgc_tracer_names is None or bgc_tracer_names == {}:
             return
 
         # Read in the forcing datasets

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1536,7 +1536,7 @@ class experiment:
         """
 
         if bgc_tracer_names is None:
-            bgc_tracer_names = {}
+            return
 
         # Read in the forcing datasets
         datasets = {}

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -3347,10 +3347,7 @@ def apply_arakawa_grid_mapping(var_mapping: dict, arakawa_grid: str = None) -> d
             "eta_var_name": var_mapping["eta"],
             "time_var_name": var_mapping["time"],
             "depth_coord": var_mapping["zl"],
-            "tracer_var_names": {
-                "salt": var_mapping["tracers"]["salt"],
-                "temp": var_mapping["tracers"]["temp"],
-            },
+            "tracer_var_names": var_mapping["tracers"] # validate_var_mapping will ensure this is a nested dict with "salt" and "temp" keys
         }
 
         if arakawa_grid == "A":

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1309,7 +1309,6 @@ class experiment:
             var: {"_FillValue": -1e20, "missing_value": -1e20}
             for var in reprocessed_var_map["tracer_var_names"].keys()
         }
-        breakpoint()
         tracers_out.to_netcdf(
             self.mom_input_dir / "init_tracers.nc",
             mode="w",

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1,5 +1,3 @@
-import re
-
 import numpy as np
 import dask.array as da
 import xarray as xr

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1454,6 +1454,7 @@ class experiment:
         rotational_method=rot.RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
+        time_units="days"
     ):
         """
         A wrapper for :func:`~setup_single_boundary`. Given a list of up to four cardinal directions,
@@ -1523,6 +1524,7 @@ class experiment:
                 rotational_method=rotational_method,
                 regridding_method=regridding_method,
                 fill_method=fill_method,
+                time_units=time_units,
             )
 
         # Scrape the bgc var names into their own files for the boundary conditions (required for generic tracers at the moment, Apr 2026)
@@ -1573,6 +1575,7 @@ class experiment:
         rotational_method=rot.RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
+        time_units="days", 
     ):
         """
         Set up a boundary forcing file for a given ``orientation``.
@@ -1627,6 +1630,7 @@ class experiment:
             rotational_method=rotational_method,
             regridding_method=regridding_method,
             fill_method=fill_method,
+            time_units=time_units,  
         )
 
         print("Done.")
@@ -2859,7 +2863,7 @@ class segment:
 
             segment_out.time.attrs = {
                 "calendar": calendar,
-                "units": f"{time_units} since {self.startdate}",
+                "units": f" days since {self.startdate}",
             }
         else:
             segment_out.time.attrs = {

--- a/tests/test_arakawa_grid_mapping.py
+++ b/tests/test_arakawa_grid_mapping.py
@@ -1,5 +1,5 @@
 import pytest
-from regional_mom6.regional_mom6 import identify_arakawa_grid
+from regional_mom6.regional_mom6 import apply_arakawa_grid_mapping, identify_arakawa_grid
 
 
 def _make_var_map(u_x, v_x, tracer_x, u_y="lat_u", v_y="lat_v", tracer_y="lat_t"):
@@ -65,3 +65,17 @@ def test_arakawa_c_grid_requires_distinct_v_y():
     )
     with pytest.raises(ValueError, match="Could not determine Arakawa grid type"):
         identify_arakawa_grid(var_map)
+
+
+# apply_arakawa_grid_mapping tests
+
+def test_extra_tracers_carried_through():
+    """Extra tracers beyond salt/temp must appear in tracer_var_names after mapping."""
+    tracers = {"salt": "so", "temp": "thetao", "no3": "no3", "o2": "o2"}
+    var_map = {
+        "xh": "lon", "yh": "lat", "xq": None, "yq": None,
+        "u": "uo", "v": "vo", "eta": "zos", "time": "time",
+        "zl": "lev", "tracers": tracers,
+    }
+    result = apply_arakawa_grid_mapping(var_map, arakawa_grid="A")
+    assert result["tracer_var_names"] == tracers

--- a/tests/test_arakawa_grid_mapping.py
+++ b/tests/test_arakawa_grid_mapping.py
@@ -1,5 +1,8 @@
 import pytest
-from regional_mom6.regional_mom6 import apply_arakawa_grid_mapping, identify_arakawa_grid
+from regional_mom6.regional_mom6 import (
+    apply_arakawa_grid_mapping,
+    identify_arakawa_grid,
+)
 
 
 def _make_var_map(u_x, v_x, tracer_x, u_y="lat_u", v_y="lat_v", tracer_y="lat_t"):
@@ -69,13 +72,21 @@ def test_arakawa_c_grid_requires_distinct_v_y():
 
 # apply_arakawa_grid_mapping tests
 
+
 def test_extra_tracers_carried_through():
     """Extra tracers beyond salt/temp must appear in tracer_var_names after mapping."""
     tracers = {"salt": "so", "temp": "thetao", "no3": "no3", "o2": "o2"}
     var_map = {
-        "xh": "lon", "yh": "lat", "xq": None, "yq": None,
-        "u": "uo", "v": "vo", "eta": "zos", "time": "time",
-        "zl": "lev", "tracers": tracers,
+        "xh": "lon",
+        "yh": "lat",
+        "xq": None,
+        "yq": None,
+        "u": "uo",
+        "v": "vo",
+        "eta": "zos",
+        "time": "time",
+        "zl": "lev",
+        "tracers": tracers,
     }
     result = apply_arakawa_grid_mapping(var_map, arakawa_grid="A")
     assert result["tracer_var_names"] == tracers

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -211,6 +211,57 @@ def test_ocean_forcing(
     dask.config.set(scheduler=None)
 
 
+def test_bgc_tracers_carried_through_initial_condition(tmp_path, generate_silly_ic_dataset):
+    """BGC tracers beyond temp/salt must appear in ic_tracers after setup_initial_condition."""
+    dask.config.set(scheduler="single-threaded")
+    lon_ext = [-5, 3]
+    lat_ext = [0, 10]
+    nz = 5
+
+    initial_cond = generate_silly_ic_dataset(
+        lon_ext, lat_ext, resolution, nz, depth,
+        get_temperature_dataarrays(lon_ext, lat_ext, resolution, nz, depth)[0],
+    )
+    # Add a BGC tracer
+    nx, ny = number_of_gridpoints(lon_ext, lat_ext, resolution)
+    silly_lat, silly_lon, silly_depth = initial_cond.silly_lat, initial_cond.silly_lon, initial_cond.silly_depth
+    initial_cond["no3"] = xr.DataArray(
+        np.random.random((ny, nx, nz)),
+        dims=["silly_lat", "silly_lon", "silly_depth"],
+        coords={"silly_lat": silly_lat, "silly_lon": silly_lon, "silly_depth": silly_depth},
+    )
+    initial_cond.to_netcdf(tmp_path / "ic_bgc")
+    initial_cond.close()
+
+    expt = experiment(
+        longitude_extent=lon_ext,
+        latitude_extent=lat_ext,
+        date_range=date_range,
+        resolution=resolution,
+        number_vertical_layers=nz,
+        layer_thickness_ratio=layer_thickness_ratio,
+        depth=depth,
+        mom_run_dir=tmp_path / "rundir",
+        mom_input_dir=tmp_path / "inputdir",
+        fre_tools_dir="toolpath",
+        hgrid_type="even_spacing",
+    )
+    varnames = {
+        "xh": "silly_lon",
+        "yh": "silly_lat",
+        "time": "time",
+        "eta": "eta",
+        "zl": "silly_depth",
+        "u": "u",
+        "v": "v",
+        "tracers": {"temp": "temp", "salt": "salt", "no3": "no3"},
+    }
+    expt.setup_initial_condition(tmp_path / "ic_bgc", varnames, arakawa_grid="A")
+
+    assert "no3" in expt.ic_tracers
+    dask.config.set(scheduler=None)
+
+
 @pytest.mark.parametrize(
     (
         "longitude_extent",

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -211,7 +211,9 @@ def test_ocean_forcing(
     dask.config.set(scheduler=None)
 
 
-def test_bgc_tracers_carried_through_initial_condition(tmp_path, generate_silly_ic_dataset):
+def test_bgc_tracers_carried_through_initial_condition(
+    tmp_path, generate_silly_ic_dataset
+):
     """BGC tracers beyond temp/salt must appear in ic_tracers after setup_initial_condition."""
     dask.config.set(scheduler="single-threaded")
     lon_ext = [-5, 3]
@@ -219,16 +221,28 @@ def test_bgc_tracers_carried_through_initial_condition(tmp_path, generate_silly_
     nz = 5
 
     initial_cond = generate_silly_ic_dataset(
-        lon_ext, lat_ext, resolution, nz, depth,
+        lon_ext,
+        lat_ext,
+        resolution,
+        nz,
+        depth,
         get_temperature_dataarrays(lon_ext, lat_ext, resolution, nz, depth)[0],
     )
     # Add a BGC tracer
     nx, ny = number_of_gridpoints(lon_ext, lat_ext, resolution)
-    silly_lat, silly_lon, silly_depth = initial_cond.silly_lat, initial_cond.silly_lon, initial_cond.silly_depth
+    silly_lat, silly_lon, silly_depth = (
+        initial_cond.silly_lat,
+        initial_cond.silly_lon,
+        initial_cond.silly_depth,
+    )
     initial_cond["no3"] = xr.DataArray(
         np.random.random((ny, nx, nz)),
         dims=["silly_lat", "silly_lon", "silly_depth"],
-        coords={"silly_lat": silly_lat, "silly_lon": silly_lon, "silly_depth": silly_depth},
+        coords={
+            "silly_lat": silly_lat,
+            "silly_lon": silly_lon,
+            "silly_depth": silly_depth,
+        },
     )
     initial_cond.to_netcdf(tmp_path / "ic_bgc")
     initial_cond.close()

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -292,6 +292,20 @@ def test_rectangular_boundaries(
                     "time": np.linspace(0, 1000, 10),
                 },
             ),
+            "o2": xr.DataArray(
+                np.random.random((100, 5, 10, 10)),
+                dims=["silly_lat", "silly_lon", "silly_depth", "time"],
+                coords={
+                    "silly_lat": np.linspace(
+                        latitude_extent[0] - 5, latitude_extent[1] + 5, 100
+                    ),
+                    "silly_lon": np.linspace(
+                        longitude_extent[1] - 0.5, longitude_extent[1] + 0.5, 5
+                    ),
+                    "silly_depth": np.linspace(0, 1000, 10),
+                    "time": np.linspace(0, 1000, 10),
+                },
+            ),
             "u": xr.DataArray(
                 np.random.random((100, 5, 10, 10)),
                 dims=["silly_lat", "silly_lon", "silly_depth", "time"],
@@ -351,7 +365,13 @@ def test_rectangular_boundaries(
         "v": "v",
         "tracers": {"temp": "temp", "salt": "salt"},
     }
-    expt.setup_ocean_state_boundaries(tmp_path, varnames)
+
+    # Add test for bgc_tracer_names
+    bgc_tracer_names = {"o2": "o2"}
+    expt.setup_ocean_state_boundaries(tmp_path, varnames, bgc_tracer_names = bgc_tracer_names)
+    assert (expt.inputdir/"o2_obc_segment.nc").exists(), "BGC tracer file not created"
+
+
 
 
 def test_reformat_bgc_tracers_into_files(tmp_path):

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -433,7 +433,7 @@ def test_rectangular_boundaries(
     # Add test for bgc_tracer_names
     bgc_tracer_names = {"o2": "o2"}
     expt.setup_ocean_state_boundaries(tmp_path, varnames, bgc_tracer_names = bgc_tracer_names)
-    assert (expt.inputdir/"o2_obc_segment.nc").exists(), "BGC tracer file not created"
+    assert (expt.mom_input_dir/"o2_obc_segment.nc").exists(), "BGC tracer file not created"
 
 
 

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -215,7 +215,6 @@ def test_bgc_tracers_carried_through_initial_condition(
     tmp_path, generate_silly_ic_dataset
 ):
     """BGC tracers beyond temp/salt must appear in ic_tracers after setup_initial_condition."""
-    dask.config.set(scheduler="single-threaded")
     lon_ext = [-5, 3]
     lat_ext = [0, 10]
     nz = 5

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -352,3 +352,56 @@ def test_rectangular_boundaries(
         "tracers": {"temp": "temp", "salt": "salt"},
     }
     expt.setup_ocean_state_boundaries(tmp_path, varnames)
+
+
+def test_reformat_bgc_tracers_into_files(tmp_path):
+    """reformat_bgc_tracers_into_files writes one file per BGC tracer containing the tracer and its dz variable."""
+    expt = experiment(
+        longitude_extent=[-5, 5],
+        latitude_extent=[0, 10],
+        date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+        resolution=0.1,
+        number_vertical_layers=5,
+        layer_thickness_ratio=1,
+        depth=1000,
+        mom_run_dir=tmp_path / "rundir",
+        mom_input_dir=tmp_path / "inputdir",
+        fre_tools_dir="toolpath",
+        hgrid_type="even_spacing",
+        boundaries=["east", "west"],
+    )
+
+    # Write a fake forcing_obc_segment_001.nc with BGC tracer vars
+    segs = ["001", "002"]
+    for seg in segs:
+        ds = xr.Dataset(
+            {
+                f"o2_segment_{seg}": xr.DataArray(
+                    np.random.random((3, 5, 4)),
+                    dims=["time", "nz", f"nx_segment_{seg}"],
+                ),
+                f"dz_o2_segment_{seg}": xr.DataArray(
+                    np.random.random((3, 5, 4)),
+                    dims=["time", "nz", f"nx_segment_{seg}"],
+                ),
+                f"temp_segment_{seg}": xr.DataArray(
+                    np.random.random((3, 5, 4)),
+                    dims=["time", "nz", f"nx_segment_{seg}"],
+                ),
+            }
+        )
+        ds.to_netcdf(expt.mom_input_dir / f"forcing_obc_segment_{seg}.nc")
+
+    expt.reformat_bgc_tracers_into_files({"o2": "o2"})
+
+    out_file = expt.mom_input_dir / "o2_obc_segment.nc"
+    assert out_file.exists(), "output file for BGC tracer not created"
+    result = xr.open_dataset(out_file)
+    for seg in segs:
+        assert f"o2_segment_{seg}" in result, "tracer variable missing from output"
+        assert (
+            f"dz_o2_segment_{seg}" in result
+        ), "dz thickness variable missing from output"
+        assert (
+            f"temp_segment_{seg}" not in result
+        ), "physical tracer should not be in BGC file"

--- a/tests/test_identify_arakawa_grid.py
+++ b/tests/test_identify_arakawa_grid.py
@@ -1,0 +1,67 @@
+import pytest
+from regional_mom6.regional_mom6 import identify_arakawa_grid
+
+
+def _make_var_map(u_x, v_x, tracer_x, u_y="lat_u", v_y="lat_v", tracer_y="lat_t"):
+    return {
+        "u_x_coord": u_x,
+        "v_x_coord": v_x,
+        "tracer_x_coord": tracer_x,
+        "u_y_coord": u_y,
+        "v_y_coord": v_y,
+        "tracer_y_coord": tracer_y,
+    }
+
+
+def test_arakawa_a_grid():
+    """All velocity and tracer points share the same x coordinate -> A grid."""
+    var_map = _make_var_map(u_x="lon", v_x="lon", tracer_x="lon")
+    assert identify_arakawa_grid(var_map) == "A"
+
+
+def test_arakawa_b_grid():
+    """u and v share x coordinate, but differ from tracer -> B grid."""
+    var_map = _make_var_map(u_x="lon_uv", v_x="lon_uv", tracer_x="lon_t")
+    assert identify_arakawa_grid(var_map) == "B"
+
+
+def test_arakawa_c_grid():
+    """u, v, and tracer all on different x coordinates, and v_y != tracer_y -> C grid."""
+    var_map = _make_var_map(
+        u_x="lon_u",
+        v_x="lon_t",
+        tracer_x="lon_t",
+        v_y="lat_v",
+        u_y="lat_t",
+        tracer_y="lat_t",
+    )
+    assert identify_arakawa_grid(var_map) == "C"
+
+
+def test_arakawa_raises_when_indeterminate():
+    """v_x != u_x but u_x == tracer_x (and v_y == tracer_y) cannot be classified."""
+    var_map = _make_var_map(
+        u_x="lon_t",
+        v_x="lon_v",
+        tracer_x="lon_t",
+        v_y="lat_t",
+        tracer_y="lat_t",
+    )
+    with pytest.raises(ValueError, match="Could not determine Arakawa grid type"):
+        identify_arakawa_grid(var_map)
+
+
+def test_arakawa_c_grid_requires_distinct_v_y():
+    """
+    v_x != u_x and u_x != tracer_x, but v_y == tracer_y -> should not be C grid.
+    The else branch raises ValueError.
+    """
+    var_map = _make_var_map(
+        u_x="lon_u",
+        v_x="lon_v",
+        tracer_x="lon_t",
+        v_y="lat_shared",
+        tracer_y="lat_shared",
+    )
+    with pytest.raises(ValueError, match="Could not determine Arakawa grid type"):
+        identify_arakawa_grid(var_map)


### PR DESCRIPTION
Allow `setup_ocean_state_boundaries` to accept forcing data with any time units (e.g. hours, days, months) via `time_units`. Previously only daily data was supported. 