### PR TITLE
Move chl.py chlorophyll interpolation into regional-mom6

### DIFF
--- a/regional_mom6/chl.py
+++ b/regional_mom6/chl.py
@@ -1,0 +1,1 @@
+from mom6_forge.chl import *

--- a/regional_mom6/chl.py
+++ b/regional_mom6/chl.py
@@ -1,1 +1,252 @@
-from mom6_forge.chl import *
+from mom6_forge.grid import Grid
+from mom6_forge.topo import Topo
+import xarray as xr
+import numpy as np
+import xesmf as xe
+from datetime import datetime
+from pathlib import Path
+from os.path import isfile
+from mom6_forge.utils import fill_missing_data, compute_subsampling_factor
+from mom6_forge.mapping import regrid_with_subsampling
+
+
+def interpolate_and_fill_seawifs(
+    grid: Grid,
+    topo: Topo,
+    processed_seawifs_path: Path | str,
+    output_path: Path | str = None,
+):
+    """
+    Interpolate and fill SeaWiFS chlorophyll data to a model grid and save to NetCDF.
+
+    This function assumes a NO_LEAP calendar.
+
+    This function takes gridded SeaWiFS chlorophyll data, interpolates it onto a
+    super-sampled model grid, applies ocean masking, fills missing values, and writes
+    the processed data to a NetCDF file. Global attributes are added to the output
+    dataset to document provenance and authorship.
+
+    Parameters
+    ----------
+    grid : Grid
+        Model grid object containing tracer longitude and latitude arrays (`grid.tlon`, `grid.tlat`)
+        and other grid arrays (`grid.qlon`, `grid.qlat`, `grid.nx`, `grid.ny`).
+    topo : Topo
+        Topography object containing the ocean mask (`topo.tmask`).
+    processed_seawifs_path : Path or str
+        Path to the preprocessed SeaWiFS chlorophyll dataset.
+    output_path : Path or str, optional
+        Path to save the output NetCDF file. If not provided, it is created in the same
+        directory as `processed_seawifs_path` using the grid name.
+
+    Returns
+    -------
+    xarray.Dataset
+        A dataset containing the interpolated and filled chlorophyll concentration with
+        appropriate global attributes and coordinate variables.
+    """
+    if grid.name is None:
+        grid.name = "UnknownGridName"
+
+    assert (
+        grid.is_rectangular()
+    ), "This function currently only supports rectangular grids."
+    ocn_mask = topo.tmask
+    ocn_nj, ocn_ni = ocn_mask.shape
+    src_nc = xr.open_dataset(processed_seawifs_path)
+    src_data = src_nc["chlor_a"]
+    src_nj, src_ni = src_data.shape[-2], src_data.shape[-1]
+
+    src_lon = src_nc[src_data.dims[-1]]
+    src_lat = ((np.arange(src_nj) + 0.5) / src_nj - 0.5) * 180.0  # Recompute as doubles
+
+    src_x0 = int((src_lon[0] + src_lon[-1]) / 2 + 0.5) - 180.0
+    src_lon = (
+        (np.arange(src_ni) + 0.5) / src_ni
+    ) * 360.0 + src_x0  # Recompute as doubles
+
+    ny_sub, nx_sub = compute_subsampling_factor(src_nj, src_ni, ocn_nj, ocn_ni)
+
+    # Set output path
+    if output_path is None:
+        output_path = (
+            Path(processed_seawifs_path).parent
+            / f"seawifs-clim-1997-2010-{grid.name}.nc"
+        )
+    else:
+        output_path = Path(output_path)
+
+    # Generate empty dataset to fill for chlorophyll
+    fill_value = np.float32(-1.0e34)
+    chla = gen_chl_empty_dataset(
+        output_path,
+        grid.tlon[int(grid.ny / 2), :].values,
+        grid.tlat[:, int(grid.nx / 2)].values,
+        fill_value,
+    )
+    chlor_a = chla["CHL_A"]
+
+    regridder = None
+    for t in range(src_data.shape[0]):
+
+        # Build source dataset for this timestep
+        src_ds = xr.Dataset(
+            {
+                "chlor_a": xr.DataArray(
+                    src_data[t, ::-1, :].values,
+                    dims=["lat", "lon"],
+                    coords={"lat": src_lat, "lon": src_lon},
+                )
+            }
+        )
+
+        # Regrid to super-sampled sub-point grid and average back to model grid
+        q_sub, regridder = regrid_with_subsampling(
+            input_dataset=src_ds,
+            qlon=grid.qlon.values,
+            qlat=grid.qlat.values,
+            nx_sub=nx_sub,
+            ny_sub=ny_sub,
+            regridding_method="bilinear",
+            regridder=regridder,
+        )
+        q_int = q_sub["chlor_a"].mean(dim=["ny_sub", "nx_sub"]).values
+
+        # Fill any missing data
+        q = q_int * ocn_mask
+        q_nan = np.where((q == 0) | np.isnan(q), np.nan, q)
+        chlor_a[t, :] = fill_missing_data(q_nan, ocn_mask)
+
+    # Global attributes
+    chla.attrs["title"] = (
+        "Chlorophyll Concentration, OCI Algorithm, interpolated and objectively filled to "
+        + grid.name
+    )
+    chla.attrs["repository"] = (
+        "https://github.com/NCAR/SeaWIFS_MOM6 and https://github.com/NCAR/mom6_forge"
+    )
+    chla.attrs["authors"] = (
+        "Gustavo Marques (gmarques@ucar.edu) and Frank Bryan (bryan@ucar.edu)"
+    )
+    chla.attrs["date"] = datetime.now().isoformat()
+
+    # Assign variable data
+    chla["CHL_A"].data[:] = chlor_a
+    chla["LON"] = grid.tlon[0, :]
+    chla["LAT"] = grid.tlat[:, 0]
+
+    # Write to NetCDF
+    chla.to_netcdf(
+        output_path,
+        unlimited_dims=["TIME"],
+        encoding={
+            "CHL_A": {
+                "_FillValue": fill_value,
+            }
+        },
+        format="NETCDF3_64BIT",
+    )
+    print(f"Wrote interpolated and filled SeaWiFS data to:\n{output_path}")
+
+    # Clean up weights file if it exists
+    Path("bilin_weights.nc").unlink(missing_ok=True)
+
+    return chla
+
+
+def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, no_leap=True):
+    """
+    Generate an empty NetCDF dataset for SeaWiFS chlorophyll climatology and save it to disk.
+
+    This function assumes a NO_LEAP calendar.
+
+    This function creates a synthetic xarray dataset with a CHL_A variable (monthly mean chlorophyll)
+    initialized entirely with fill values. The dataset uses the provided longitude and latitude
+    arrays to define the spatial grid and includes a fixed climatological time axis.
+
+    Parameters
+    ----------
+    output_path : str or Path
+        Path to save the output NetCDF file.
+
+    lon : array-like
+        1D array of longitude values (in degrees east) defining the spatial X-axis.
+
+    lat : array-like
+        1D array of latitude values (in degrees north) defining the spatial Y-axis.
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        The generated empty dataset containing the CHL_A variable and coordinate metadata.
+
+    Notes
+    -----
+    - The CHL_A variable is filled with the placeholder value -1e34.
+    - The TIME dimension is fixed and marked as unlimited in the NetCDF file.
+    - TIME values represent the approximate midpoint of each month in a climatological year.
+    - This dataset structure mimics that of SeaWiFS chlorophyll climatology products and is intended
+      as a template or placeholder.
+    """
+
+    # === Coordinates ===
+
+    if no_leap:
+        time = np.array(
+            [15.5, 45, 74.5, 105, 135.5, 166, 196.5, 227.5, 258, 288.5, 319, 349.5]
+        )
+    else:
+        time = np.array(
+            [15.5, 45.5, 75.5, 106, 136.5, 167, 197.5, 228.5, 259, 289.5, 320, 350.5]
+        )
+
+    # === Placeholder data for CHL_A (all fill values) ===
+    fill_value = np.float32(-1.0e34)
+    chl_a_data = np.empty((len(time), len(lat), len(lon)), dtype=np.float32)
+
+    # === xarray Dataset ===
+    ds = xr.Dataset(
+        {
+            "CHL_A": xr.DataArray(
+                chl_a_data,
+                dims=["TIME", "LAT", "LON"],
+                coords={"TIME": time, "LAT": lat, "LON": lon},
+                attrs={
+                    "long_name": "CHL_A = monthly mean",
+                    "units": "mg/m^3",
+                    "missing_value": fill_value,
+                },
+            )
+        },
+        coords={
+            "LON": xr.DataArray(
+                lon, dims="LON", attrs={"units": "degrees_east", "axis": "X"}
+            ),
+            "LAT": xr.DataArray(
+                lat, dims="LAT", attrs={"units": "degrees_north", "axis": "Y"}
+            ),
+            "TIME": xr.DataArray(
+                time,
+                dims="TIME",
+                attrs={
+                    "units": "days since 0001-01-01 00:00:00",
+                    "calendar": "NOLEAP",
+                    "modulo": " ",
+                    "axis": "T",
+                    "cartesian_axis": "T",
+                },
+            ),
+        },
+        attrs={  # Global attributes
+            "title": "SeaWiFS Chlorophyll Climatology (1997–2010)",
+            "institution": "Generated by xarray",
+            "source": "SeaWifs and NASA",
+            "history": "",
+        },
+    )
+
+    return ds
+
+
+if __name__ == "__main__":
+    interpolate_and_fill_seawifs()

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -45,6 +45,9 @@ __all__ = [
     "get_glorys_data",
     "RotationMethod",
     "get_rotation_angle",
+    "Grid",
+    "Topo",
+    "VGrid",
 ]
 
 

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -14,7 +14,6 @@ import importlib.resources
 import pandas as pd
 from pathlib import Path
 import json
-from enum import Enum
 from ruamel.yaml import YAML
 from regional_mom6 import MOM_parameter_tools as mpt
 from regional_mom6 import regridding as rgd
@@ -28,7 +27,6 @@ from regional_mom6.utils import (
     rotate,
     find_files_by_pattern,
     try_pint_convert,
-    is_rectilinear_hgrid,
 )
 from mom6_forge._supergrid import SupergridBase
 from mom6_forge.utils import longitude_slicer
@@ -43,76 +41,39 @@ __all__ = [
     "experiment",
     "segment",
     "get_glorys_data",
-    "RotationMethod",
-    "get_rotation_angle",
     "Grid",
     "Topo",
     "VGrid",
 ]
 
 
-class RotationMethod(Enum):
-    """Prescribes the rotational method used in boundary conditions when the grid
-    does not have coordinates along lines of constant longitude-latitude.
+def _get_angle_dx(hgrid: xr.Dataset, orientation=None) -> xr.DataArray:
+    """Return the MOM6-consistent ``angle_dx`` rotation angle (degrees) for the hgrid,
+    or a boundary slice of it.
 
-    Attributes:
-        EXPAND_GRID (int): Finds angles at q/u/v points by expanding the hgrid by one
-            row/column, replicating exactly what MOM6 does.
-        GIVEN_ANGLE (int): Expects a pre-given angle called ``angle_dx``.
-        NO_ROTATION (int): Grid is along lines of constant latitude-longitude; no rotation required.
-    """
-
-    EXPAND_GRID = 1
-    GIVEN_ANGLE = 2
-    NO_ROTATION = 3
-
-
-def get_rotation_angle(
-    rotational_method: RotationMethod, hgrid: xr.Dataset, orientation=None
-) -> xr.DataArray:
-    """Return the rotation angle (degrees) for the hgrid or a boundary slice of it.
+    ``angle_dx`` is computed by mom6_forge (via the expanded-supergrid method) at grid
+    construction time and is always present on ``experiment.hgrid``; see
+    :meth:`~experiment.recalculate_rotation_angle` if it ever needs to be refreshed.
 
     Parameters
     ----------
-    rotational_method : RotationMethod
     hgrid : xr.Dataset
     orientation : str, optional
         If given (e.g. ``"north"``), return only the boundary slice.
     """
-    boundary = orientation is not None
+    if orientation is not None:
+        return rgd.coords(
+            hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx"
+        )["angle"]
+    return hgrid["angle_dx"]
 
-    if rotational_method == RotationMethod.NO_ROTATION:
-        if not is_rectilinear_hgrid(hgrid):
-            raise ValueError("NO_ROTATION method only works with rectilinear grids")
-        angles = xr.zeros_like(hgrid.x)
-        if boundary:
-            hgrid["zero_angle"] = angles
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="zero_angle"
-            )["angle"]
-        return angles
 
-    elif rotational_method == RotationMethod.GIVEN_ANGLE:
-        if boundary:
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx"
-            )["angle"]
-        return hgrid["angle_dx"]
-
-    elif rotational_method == RotationMethod.EXPAND_GRID:
-        hgrid["angle_dx_rm6"] = xr.DataArray(
-            SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
-                hgrid.x.values, hgrid.y.values
-            ),
-            dims=hgrid.x.dims,
-        )
-        if boundary:
-            return rgd.coords(
-                hgrid, orientation, "doesnt_matter", angle_variable_name="angle_dx_rm6"
-            )["angle"]
-        return hgrid["angle_dx_rm6"]
-
-    raise ValueError("Invalid rotational method")
+# Maximum tolerated disagreement (in degrees) between an hgrid.nc file's stored
+# `angle_dx` and the angle MOM6's expanded-supergrid method computes from the same
+# grid's x/y coordinates, before `experiment.hgrid` refuses to use it. A large
+# disagreement usually means the file's `angle_dx` came from a different tool or
+# rotation convention than mom6_forge/MOM6 expect.
+ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES = 5.0
 
 
 # If the array is pint possible, ensure we have the right units for main fields (eta, u, v, temp),
@@ -226,27 +187,36 @@ class experiment:
     Arguments:
         date_range (Tuple[str]): Start and end dates of the boundary forcing window. For
             example: ``("2003-01-01", "2003-01-31")``.
-        resolution (float): Lateral resolution of the domain (in degrees).
-        number_vertical_layers (int): Number of vertical layers.
-        layer_thickness_ratio (float): Ratio of largest to smallest layer thickness;
-            used as input in :func:`~hyperbolictan_thickness_profile`.
-        depth (float): Depth of the domain.
         mom_run_dir (str): Path of the MOM6 control directory.
         mom_input_dir (str): Path of the MOM6 input directory, to receive the forcing files.
+        resolution (float, optional): Lateral resolution of the domain (in degrees). Required
+            only when ``hgrid_type`` doesn't already provide a ``Grid`` object (i.e., you need
+            one to be generated from ``longitude_extent``/``latitude_extent``).
+        number_vertical_layers (int, optional): Number of vertical layers. Required only when
+            ``vgrid_type`` doesn't already provide a ``VGrid`` object.
+        layer_thickness_ratio (float, optional): Ratio of largest to smallest layer thickness;
+            used as input in :func:`~hyperbolictan_thickness_profile`. Required only when
+            ``vgrid_type`` doesn't already provide a ``VGrid`` object.
+        depth (float, optional): Depth of the domain. Required only when ``vgrid_type`` doesn't
+            already provide a ``VGrid`` object.
         fre_tools_dir (str): Path of GFDL's FRE tools (https://github.com/NOAA-GFDL/FRE-NCtools)
             binaries.
-        longitude_extent (Tuple[float]): Extent of the region in longitude (in degrees). For
-            example: ``(40.5, 50.0)``.
-        latitude_extent (Tuple[float]): Extent of the region in latitude (in degrees). For
-            example: ``(-20.0, 30.0)``.
+        longitude_extent (Tuple[float], optional): Extent of the region in longitude (in degrees). For
+            example: ``(40.5, 50.0)``. Required only when ``hgrid_type`` doesn't already provide a
+            ``Grid`` object.
+        latitude_extent (Tuple[float], optional): Extent of the region in latitude (in degrees). For
+            example: ``(-20.0, 30.0)``. Required only when ``hgrid_type`` doesn't already provide a
+            ``Grid`` object.
         hgrid_type (str or Grid): Type of horizontal grid to generate. Currently, only ``'even_spacing'`` is supported.
             Setting this argument to ``'from_file'`` lazily reads ``hgrid.nc`` from ``mom_input_dir`` the first time
             the ``hgrid`` property is accessed. You can also pass a mom6_forge ``Grid`` object directly, in which case
-            ``hgrid`` is derived from it instead of touching disk.
+            ``hgrid`` is derived from it instead of touching disk, and ``resolution``/``longitude_extent``/
+            ``latitude_extent`` are not required.
         vgrid_type (str or VGrid): Type of vertical grid to generate. Currently, only ``'hyperbolic_tangent'`` is
             supported. Setting this argument to ``'from_file'`` lazily reads ``vgrid.nc`` from ``mom_input_dir`` the
             first time the ``vgrid`` property is accessed. You can also pass a mom6_forge ``VGrid`` object directly, in
-            which case ``vgrid`` is derived from it instead of touching disk.
+            which case ``vgrid`` is derived from it instead of touching disk, and ``number_vertical_layers``/
+            ``layer_thickness_ratio``/``depth`` are not required.
         repeat_year_forcing (bool): When ``True`` the experiment runs with
             repeat-year forcing. When ``False`` (default) then inter-annual forcing is used.
         minimum_depth (int): The minimum depth in meters of a grid cell allowed before it is masked out and treated as land.
@@ -344,12 +314,12 @@ class experiment:
         self,
         *,
         date_range,
-        resolution,
-        number_vertical_layers,
-        layer_thickness_ratio,
-        depth,
         mom_run_dir,
         mom_input_dir,
+        resolution=None,
+        number_vertical_layers=None,
+        layer_thickness_ratio=None,
+        depth=None,
         fre_tools_dir=None,
         longitude_extent=None,
         latitude_extent=None,
@@ -419,17 +389,24 @@ class experiment:
                 float(self.hgrid.y.max()),
             )
         elif hgrid_type == "from_file":
-            # `self.hgrid` lazily reads `mom_input_dir/hgrid.nc` the first time
-            # it's accessed.
-            self.longitude_extent = (
-                float(self.hgrid.x.min()),
-                float(self.hgrid.x.max()),
-            )
-            self.latitude_extent = (
-                float(self.hgrid.y.min()),
-                float(self.hgrid.y.max()),
-            )
+            # `self.hgrid` lazily reads `mom_input_dir/hgrid.nc` the first time it's
+            # accessed. A rotation-angle discrepancy here is only warned about (not
+            # raised), so construction can still succeed and the user has a live
+            # `experiment` to call `recalculate_rotation_angle()` on afterward.
+            hgrid = self.hgrid
+            hgrid = self.m6f_hgrid.supergrid.to_ds()
+            self.longitude_extent = (float(hgrid.x.min()), float(hgrid.x.max()))
+            self.latitude_extent = (float(hgrid.y.min()), float(hgrid.y.max()))
         else:
+            assert (
+                resolution is not None
+                and longitude_extent is not None
+                and latitude_extent is not None
+            ), (
+                "`resolution`, `longitude_extent`, and `latitude_extent` are required "
+                "to generate an hgrid; pass a mom6_forge `Grid` object via `hgrid_type` "
+                "instead if you don't want to specify them."
+            )
             self.longitude_extent = tuple(longitude_extent)
             self.latitude_extent = tuple(latitude_extent)
             self._make_hgrid()  # sets `self.m6f_hgrid`; `self.hgrid` derives from it
@@ -441,6 +418,15 @@ class experiment:
             # it's accessed.
             pass
         else:
+            assert (
+                number_vertical_layers is not None
+                and layer_thickness_ratio is not None
+                and depth is not None
+            ), (
+                "`number_vertical_layers`, `layer_thickness_ratio`, and `depth` are "
+                "required to generate a vgrid; pass a mom6_forge `VGrid` object via "
+                "`vgrid_type` instead if you don't want to specify them."
+            )
             self._make_vgrid()  # sets `self.m6f_vgrid`; `self.vgrid` derives from it
 
         self.segments = {}
@@ -468,7 +454,10 @@ class experiment:
 
         If ``m6f_hgrid`` hasn't been supplied yet -- passed in directly via
         ``hgrid_type``, or generated by ``_make_hgrid`` -- it's lazily built from
-        ``hgrid.nc`` in ``mom_input_dir`` the first time this property is accessed.
+        ``hgrid.nc`` in ``mom_input_dir`` the first time this property is accessed. On
+        that first load, the file's ``angle_dx`` is checked against the angle MOM6's
+        expanded-supergrid method would compute from the grid's ``x``/``y``
+        coordinates; see :meth:`recalculate_rotation_angle`.
         """
         if self.m6f_hgrid is None:
             hgrid_path = self.mom_input_dir / "hgrid.nc"
@@ -479,7 +468,45 @@ class experiment:
                     "object via `hgrid_type`."
                 )
             self.m6f_hgrid = Grid.from_supergrid(hgrid_path)
+            self._validate_hgrid_rotation_angle(source=hgrid_path)
         return self.m6f_hgrid.supergrid.to_ds()
+
+    def _validate_hgrid_rotation_angle(self, source):
+        """Compare the loaded hgrid's stored ``angle_dx`` against the angle MOM6's
+        expanded-supergrid method computes from its ``x``/``y`` coordinates, and raise
+        if they disagree by more than :data:`ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES`.
+        """
+        supergrid = self.m6f_hgrid.supergrid
+        expected_angle_dx = SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
+            supergrid.x, supergrid.y
+        )
+        max_discrepancy = float(
+            np.nanmax(np.abs(supergrid.angle_dx - expected_angle_dx))
+        )
+        if max_discrepancy > ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES:
+            warnings.warn(
+                f"The `angle_dx` stored in {source} disagrees with the angle MOM6's "
+                f"expanded-supergrid method computes from the grid's x/y coordinates "
+                f"by up to {max_discrepancy:.2f} degrees (threshold: "
+                f"{ANGLE_DX_DISCREPANCY_THRESHOLD_DEGREES} degrees). This usually means "
+                "the hgrid.nc came from a different tool or rotation convention. If the "
+                "MOM6-consistent angle is what you actually want, call "
+                "`recalculate_rotation_angle()` to overwrite it."
+            )
+
+    def recalculate_rotation_angle(self):
+        """Recompute ``angle_dx`` for the current hgrid using MOM6's
+        expanded-supergrid method, overwriting whatever is currently stored.
+
+        Call this after hand-editing the hgrid's coordinates (e.g. via
+        ``TopoEditor``/manual rotation), or if :attr:`hgrid` raised a discrepancy
+        error and the MOM6-consistent angle is what you want.
+        """
+        assert self.hgrid is not None, "No hgrid available"
+        supergrid = self.m6f_hgrid.supergrid
+        supergrid.angle_dx = SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
+            supergrid.x, supergrid.y
+        )
 
     @property
     def vgrid(self):
@@ -767,7 +794,6 @@ class experiment:
         varnames,
         arakawa_grid="A",
         vcoord_type="height",
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
     ):
         """
@@ -782,7 +808,6 @@ class experiment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             vcoord_type (Optional[str]): The type of vertical coordinate used in the forcing files.
                 Either ``'height'`` or ``'thickness'``.
-            rotational_method (Optional[RotationMethod]): The method used to rotate the velocities.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
         """
         if regridding_method is None:
@@ -968,9 +993,7 @@ class experiment:
         rotated_u, rotated_v = rotate(
             regridded_u,
             regridded_v,
-            radian_angle=np.radians(
-                get_rotation_angle(rotational_method, hgrid).values
-            ),
+            radian_angle=np.radians(_get_angle_dx(hgrid).values),
         )
 
         # Slice the velocites to the u and v grid.
@@ -1237,7 +1260,6 @@ class experiment:
         bgc_tracer_names: dict = None,
         arakawa_grid="A",
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1258,8 +1280,6 @@ class experiment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (Optional[str]): Path to the bathymetry file. Default is ``None``, in which case the
                 boundary condition is not masked.
-            rotational_method (Optional[str]): Method to use for rotating the boundary velocities.
-                Default is ``EXPAND_GRID``.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``self.fill_method``
         """
@@ -1306,7 +1326,6 @@ class experiment:
                 ),  # A number to identify the boundary; indexes from 1
                 arakawa_grid=arakawa_grid,
                 bathymetry_path=bathymetry_path,
-                rotational_method=rotational_method,
                 regridding_method=regridding_method,
                 fill_method=fill_method,
             )
@@ -1356,7 +1375,6 @@ class experiment:
         segment_number,
         arakawa_grid="A",
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1378,8 +1396,6 @@ class experiment:
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case
                 the boundary condition is not masked.
-            rotational_method (Optional[str]): Method to use for rotating the boundary velocities.
-                Default is 'EXPAND_GRID'.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
 
@@ -1410,7 +1426,6 @@ class experiment:
             infile=path_to_bc,  # location of raw boundary
             varnames=varnames,
             arakawa_grid=arakawa_grid,
-            rotational_method=rotational_method,
             regridding_method=regridding_method,
             fill_method=fill_method,
         )
@@ -1424,7 +1439,6 @@ class experiment:
         tpxo_velocity_filepath,
         tidal_constituents=None,
         bathymetry_path=None,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method=None,
         fill_method=None,
     ):
@@ -1437,7 +1451,6 @@ class experiment:
             tpxo_velocity_filepath: Filepath to the TPXO velocity product. Generally of the form ``u_tidalversion.nc``
             tidal_constituents: List of tidal constituents to include in the regridding. Default is set in the experiment constructor (See :class:`~Experiment`)
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case the boundary condition is not masked
-            rotational_method (str): Method to use for rotating the tidal velocities. Default is 'EXPAND_GRID'.
             regridding_method (Optional[str]): The type of regridding method to use. Defaults to self.regridding_method
             fill_method (Function): Fill method to use throughout the function. Default is ``self.fill_method``
 
@@ -1532,7 +1545,6 @@ class experiment:
                 tpxo_u,
                 tpxo_h,
                 times,
-                rotational_method=rotational_method,
                 regridding_method=regridding_method,
             )
             print("Done")
@@ -2218,7 +2230,6 @@ class segment:
         infile,
         varnames: dict,
         arakawa_grid="A",
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method="bilinear",
         time_units="days",
         calendar="gregorian",
@@ -2229,7 +2240,6 @@ class segment:
         Cut out and interpolate the velocities and tracers.
 
         Arguments:
-            rotational_method (RotationMethod): The method to use for rotation of the velocities. Currently, the default method, ``EXPAND_GRID``, works even with non-rotated grids.
             infile (Union[str, Path]): Path to the raw, unprocessed boundary segment.
             varnames (Dict[str, str]): Mapping between the variable/dimension names and
             standard naming convention of this pipeline, e.g., ``{"xq": "longitude,
@@ -2308,9 +2318,7 @@ class segment:
             u_regridded,
             v_regridded,
             radian_angle=np.radians(
-                get_rotation_angle(
-                    rotational_method, self.hgrid, orientation=self.orientation
-                ).values
+                _get_angle_dx(self.hgrid, orientation=self.orientation).values
             ),
         )
 
@@ -2500,7 +2508,6 @@ class segment:
         tpxo_u,
         tpxo_h,
         times,
-        rotational_method=RotationMethod.EXPAND_GRID,
         regridding_method="bilinear",
         fill_method=rgd.fill_missing_data,
         regridders=None,
@@ -2526,8 +2533,6 @@ class segment:
             infile_td (str): Raw tidal file/directory.
             tpxo_v, tpxo_u, tpxo_h (xarray.Dataset): Specific adjusted for MOM6 tpxo datasets (Adjusted with :func:`~experiment.setup_boundary_tides`)
             times (pd.DateRange): The start date of our model period.
-            rotational_method (RotationMethod): The method to use for rotation of the velocities.
-                The default method, ``EXPAND_GRID``, works even with non-rotated grids.
             regridding_method (str): regridding method to use throughout the function. Default is ``'bilinear'``
             fill_method (Function): Fill method to use throughout the function. Default is ``rgd.fill_missing_data``
             regridders (dict, optional): Pre-built regridders with keys ``"elev"``, ``"u"``, ``"v"``.
@@ -2667,9 +2672,7 @@ class segment:
 
         # Rotate
         INC -= np.radians(
-            get_rotation_angle(
-                rotational_method, self.hgrid, orientation=self.orientation
-            ).data[np.newaxis, :]
+            _get_angle_dx(self.hgrid, orientation=self.orientation).data[np.newaxis, :]
         )
 
         ua, va, up, vp = ep2ap(SEMA, ECC, INC, PHA)

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -22,6 +22,7 @@ from regional_mom6.config import Config
 from regional_mom6.grid import Grid
 from regional_mom6.vgrid import VGrid
 from regional_mom6.topo import Topo
+from regional_mom6.chl import interpolate_and_fill_seawifs
 from regional_mom6.utils import (
     ap2ep,
     ep2ap,
@@ -1617,6 +1618,33 @@ class experiment:
             self.mom_input_dir / "bathymetry.nc",
         )
         return self.m6f_bathymetry.gen_topo_ds()
+
+    def setup_chl(self, processed_seawifs_path, output_path=None):
+        """
+        Interpolate and fill the SeaWiFS chlorophyll climatology onto the experiment's grid.
+
+        Output is saved in the input directory of the experiment, unless a different
+        ``output_path`` is provided.
+
+        Arguments:
+            processed_seawifs_path (str): Path to the preprocessed SeaWiFS chlorophyll dataset.
+            output_path (Optional[str]): Path to save the output NetCDF file. Defaults to
+                ``mom_input_dir / f"seawifs-clim-1997-2010-{expt_name}.nc"``.
+        """
+        self.hgrid  # ensures `m6f_hgrid` is populated (from disk if needed)
+        self.bathymetry  # ensures `m6f_bathymetry` is populated (from disk if needed)
+
+        if output_path is None:
+            output_path = (
+                self.mom_input_dir / f"seawifs-clim-1997-2010-{self.expt_name}.nc"
+            )
+
+        return interpolate_and_fill_seawifs(
+            self.m6f_hgrid,
+            self.m6f_bathymetry,
+            processed_seawifs_path,
+            output_path=output_path,
+        )
 
     def run_FRE_tools(self):
         """

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1872,6 +1872,14 @@ class experiment:
                 0
             ].strftime("%Y, %m, %d")
 
+        # Chlorophyll shortwave penetration, if setup_chl has been run
+        chl_files = list(Path(self.mom_input_dir).glob("seawifs-clim-*.nc"))
+        if chl_files:
+            MOM_override_dict["CHL_FILE"]["value"] = f'"{chl_files[0].name}"'
+            MOM_override_dict["CHL_FROM_FILE"]["value"] = "True"
+            MOM_override_dict["VAR_PEN_SW"]["value"] = "True"
+            MOM_override_dict["PEN_SW_NBANDS"]["value"] = 3
+
         for key, val in MOM_override_dict.items():
             if isinstance(val, dict) and key != "original":
                 MOM_override_dict[key]["override"] = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import os
 import xarray as xr
 import numpy as np
 from mom6_forge.grid import *
+from mom6_forge.vgrid import VGrid
+from mom6_forge.topo import Topo
 import regional_mom6 as rmom6
 from regional_mom6 import experiment
 
@@ -79,6 +81,23 @@ def get_curvilinear_hgrid():
         pytest.skip(
             f"Required file 'hgrid.nc' not found in {DOCKER_FILE_PATH} or {LOCAL_FILE_PATH}"
         )
+
+
+@pytest.fixture
+def grid():
+    return Grid(resolution=0.1, xstart=-5, lenx=10, ystart=0, leny=10, name="test_grid")
+
+
+@pytest.fixture
+def vgrid():
+    return VGrid.hyperbolic(5, 1000, 1)
+
+
+@pytest.fixture
+def flat_topo(grid):
+    topo = Topo(grid, min_depth=4, git=False)
+    topo.set_flat(1000.0)
+    return topo
 
 
 @pytest.fixture

--- a/tests/test_chl.py
+++ b/tests/test_chl.py
@@ -1,76 +1,140 @@
-import socket
-
 import numpy as np
 import pytest
 import xarray as xr
-
-from regional_mom6.chl import interpolate_and_fill_seawifs
-
-SEAWIFS_PATH = "/glade/campaign/cesm/cesmdata/cseg/inputdata/ocn/mom/croc/chl/data/SeaWIFS.L3m.MC.CHL.chlor_a.0.25deg.nc"
+from mom6_forge.topo import Topo
 
 
-def on_cisl_machine():
-    """Return True if the current machine is a CISL machine, False otherwise."""
-    return "hpc.ucar.edu" in socket.getfqdn()
+def _make_small_seawifs_ds():
+    """Build a tiny synthetic dataset mirroring the format of the real SeaWiFS
+    climatology product (SeaWIFS.L3m.MC.CHL.chlor_a.0.25deg.nc), but at a very
+    coarse (5deg) global resolution so it stays small and fast to interpolate.
+    """
+    nlat, nlon, ntime = 36, 72, 12
+    dlat, dlon = 180.0 / nlat, 360.0 / nlon
 
+    # Descending latitude / ascending longitude, same convention as the real product.
+    lat = (90.0 - (np.arange(nlat) + 0.5) * dlat).astype(np.float32)
+    lon = (-180.0 + (np.arange(nlon) + 0.5) * dlon).astype(np.float32)
+    time = np.array(
+        [
+            16.0,
+            45.5,
+            75.0,
+            105.5,
+            136.0,
+            166.5,
+            197.0,
+            228.0,
+            258.5,
+            289.0,
+            319.5,
+            350.0,
+        ]
+    )
 
-requires_cisl_machine = pytest.mark.skipif(
-    not on_cisl_machine(),
-    reason="Requires the SeaWiFS chlorophyll climatology, only staged on NCAR/CISL machines",
-)
+    lat_rad = np.radians(lat)
+    lon_rad = np.radians(lon)
+    month = np.arange(ntime)
 
+    chlor_a = (
+        0.2
+        + 0.05 * np.cos(lat_rad)[None, :, None]
+        + 0.01 * np.cos(lon_rad)[None, None, :]
+        + 0.01 * np.sin(2 * np.pi * month / ntime)[:, None, None]
+    ).astype(np.float64)
 
-def add_synthetic_bathymetry(expt, tmp_path):
-    """Set up random bathymetry for `expt`, same pattern as test_expt_class.py::test_setup_bathymetry."""
-    bathymetry_file = tmp_path / "bathymetry.nc"
-    bathymetry = np.random.random((100, 100)) * (-100)
-    bathymetry = xr.DataArray(
-        bathymetry,
-        dims=["silly_lat", "silly_lon"],
-        coords={
-            "silly_lat": np.linspace(
-                expt.latitude_extent[0] - 5, expt.latitude_extent[1] + 5, 100
+    chl_attrs = {
+        "long_name": "Chlorophyll Concentration, OCI Algorithm",
+        "units": "mg m^-3",
+        "standard_name": "mass_concentration_chlorophyll_concentration_in_sea_water",
+        "valid_min": np.float32(0.001),
+        "valid_max": np.float32(100.0),
+        "display_scale": "log",
+        "display_min": np.float32(0.01),
+        "display_max": np.float32(20.0),
+    }
+
+    ds = xr.Dataset(
+        {
+            "chlor_a": xr.DataArray(
+                chlor_a, dims=["time", "lat", "lon"], attrs=chl_attrs
             ),
-            "silly_lon": np.linspace(
-                expt.longitude_extent[0] - 5, expt.longitude_extent[1] + 5, 100
+            "chlor_a_cf": xr.DataArray(
+                chlor_a.copy(), dims=["time", "lat", "lon"], attrs=chl_attrs
+            ),
+            "chlor_a_cfm": xr.DataArray(
+                chlor_a.copy(), dims=["time", "lat", "lon"], attrs=chl_attrs
+            ),
+            "ocean_mask": xr.DataArray(
+                np.ones((nlat, nlon), dtype=np.int8),
+                dims=["lat", "lon"],
+                attrs={
+                    "long_name": "Ocean Mask",
+                    "flag_values": "0, 1",
+                    "flag_meanings": "0=Land or Inland Water, 1=Ocean",
+                },
+            ),
+            "land_mask": xr.DataArray(
+                np.zeros((nlat, nlon), dtype=np.int8),
+                dims=["lat", "lon"],
+                attrs={
+                    "long_name": "Land Mask",
+                    "flag_values": "0, 1",
+                    "flag_meanings": "1=Land or Inland Water, 0=Ocean",
+                },
+            ),
+        },
+        coords={
+            "time": xr.DataArray(
+                time,
+                dims="time",
+                attrs={
+                    "long_name": "Mid-Month Day of Climatological Year",
+                    "units": "days",
+                },
+            ),
+            "lat": xr.DataArray(
+                lat,
+                dims="lat",
+                attrs={
+                    "long_name": "Latitude",
+                    "units": "degrees_north",
+                    "standard_name": "latitude",
+                    "valid_min": np.float32(-90.0),
+                    "valid_max": np.float32(90.0),
+                },
+            ),
+            "lon": xr.DataArray(
+                lon,
+                dims="lon",
+                attrs={
+                    "long_name": "Longitude",
+                    "units": "degrees_east",
+                    "standard_name": "longitude",
+                    "valid_min": np.float32(-180.0),
+                    "valid_max": np.float32(180.0),
+                },
             ),
         },
     )
-    bathymetry.name = "silly_depth"
-    bathymetry.to_netcdf(bathymetry_file)
-    bathymetry.close()
-
-    expt.setup_bathymetry(
-        bathymetry_path=str(bathymetry_file),
-        longitude_coordinate_name="silly_lon",
-        latitude_coordinate_name="silly_lat",
-        vertical_coordinate_name="silly_depth",
-    )
+    return ds
 
 
-@requires_cisl_machine
-def test_interpolate_and_fill_seawifs(simple_experiment, tmp_path):
-    """Test the creation of chl files directly via interpolate_and_fill_seawifs."""
-    add_synthetic_bathymetry(simple_experiment, tmp_path)
-
-    output_path = tmp_path / "seawifs-clim-1997-2010-chl_test_grid.nc"
-    chl_ds = interpolate_and_fill_seawifs(
-        simple_experiment.m6f_hgrid,
-        simple_experiment.m6f_bathymetry,
-        processed_seawifs_path=SEAWIFS_PATH,
-        output_path=output_path,
-    )
-
-    assert output_path.exists()
-    assert "CHL_A" in chl_ds
+@pytest.fixture
+def small_seawifs_path(tmp_path):
+    path = tmp_path / "small_seawifs.nc"
+    _make_small_seawifs_ds().to_netcdf(path)
+    return path
 
 
-@requires_cisl_machine
-def test_setup_chl(simple_experiment, tmp_path):
+def test_setup_chl(simple_experiment, small_seawifs_path):
     """Test experiment.setup_chl, which wraps interpolate_and_fill_seawifs using the experiment's own grid/bathymetry."""
-    add_synthetic_bathymetry(simple_experiment, tmp_path)
 
-    chl_ds = simple_experiment.setup_chl(processed_seawifs_path=SEAWIFS_PATH)
+    topo = Topo(simple_experiment.m6f_hgrid, min_depth=10.0, git=False)
+    topo.set_flat(1000.0)
+    simple_experiment.m6f_bathymetry = topo
+
+    chl_ds = simple_experiment.setup_chl(processed_seawifs_path=small_seawifs_path)
 
     expected_output = (
         simple_experiment.mom_input_dir
@@ -78,3 +142,13 @@ def test_setup_chl(simple_experiment, tmp_path):
     )
     assert expected_output.exists()
     assert "CHL_A" in chl_ds
+
+    chl_a = chl_ds["CHL_A"]
+    assert chl_a.shape == (
+        12,
+        simple_experiment.m6f_hgrid.ny,
+        simple_experiment.m6f_hgrid.nx,
+    )
+    assert np.all(np.isfinite(chl_a.values))
+    assert np.all(chl_a.values > 0.0)
+    assert np.all(chl_a.values < 100.0)

--- a/tests/test_chl.py
+++ b/tests/test_chl.py
@@ -1,0 +1,80 @@
+import socket
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from regional_mom6.chl import interpolate_and_fill_seawifs
+
+SEAWIFS_PATH = "/glade/campaign/cesm/cesmdata/cseg/inputdata/ocn/mom/croc/chl/data/SeaWIFS.L3m.MC.CHL.chlor_a.0.25deg.nc"
+
+
+def on_cisl_machine():
+    """Return True if the current machine is a CISL machine, False otherwise."""
+    return "hpc.ucar.edu" in socket.getfqdn()
+
+
+requires_cisl_machine = pytest.mark.skipif(
+    not on_cisl_machine(),
+    reason="Requires the SeaWiFS chlorophyll climatology, only staged on NCAR/CISL machines",
+)
+
+
+def add_synthetic_bathymetry(expt, tmp_path):
+    """Set up random bathymetry for `expt`, same pattern as test_expt_class.py::test_setup_bathymetry."""
+    bathymetry_file = tmp_path / "bathymetry.nc"
+    bathymetry = np.random.random((100, 100)) * (-100)
+    bathymetry = xr.DataArray(
+        bathymetry,
+        dims=["silly_lat", "silly_lon"],
+        coords={
+            "silly_lat": np.linspace(
+                expt.latitude_extent[0] - 5, expt.latitude_extent[1] + 5, 100
+            ),
+            "silly_lon": np.linspace(
+                expt.longitude_extent[0] - 5, expt.longitude_extent[1] + 5, 100
+            ),
+        },
+    )
+    bathymetry.name = "silly_depth"
+    bathymetry.to_netcdf(bathymetry_file)
+    bathymetry.close()
+
+    expt.setup_bathymetry(
+        bathymetry_path=str(bathymetry_file),
+        longitude_coordinate_name="silly_lon",
+        latitude_coordinate_name="silly_lat",
+        vertical_coordinate_name="silly_depth",
+    )
+
+
+@requires_cisl_machine
+def test_interpolate_and_fill_seawifs(simple_experiment, tmp_path):
+    """Test the creation of chl files directly via interpolate_and_fill_seawifs."""
+    add_synthetic_bathymetry(simple_experiment, tmp_path)
+
+    output_path = tmp_path / "seawifs-clim-1997-2010-chl_test_grid.nc"
+    chl_ds = interpolate_and_fill_seawifs(
+        simple_experiment.m6f_hgrid,
+        simple_experiment.m6f_bathymetry,
+        processed_seawifs_path=SEAWIFS_PATH,
+        output_path=output_path,
+    )
+
+    assert output_path.exists()
+    assert "CHL_A" in chl_ds
+
+
+@requires_cisl_machine
+def test_setup_chl(simple_experiment, tmp_path):
+    """Test experiment.setup_chl, which wraps interpolate_and_fill_seawifs using the experiment's own grid/bathymetry."""
+    add_synthetic_bathymetry(simple_experiment, tmp_path)
+
+    chl_ds = simple_experiment.setup_chl(processed_seawifs_path=SEAWIFS_PATH)
+
+    expected_output = (
+        simple_experiment.mom_input_dir
+        / f"seawifs-clim-1997-2010-{simple_experiment.expt_name}.nc"
+    )
+    assert expected_output.exists()
+    assert "CHL_A" in chl_ds

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -492,3 +492,98 @@ def test_reformat_bgc_tracers_into_files(tmp_path):
         assert (
             f"temp_segment_{seg}" not in result
         ), "physical tracer should not be in BGC file"
+
+
+def test_experiment_from_grid_and_vgrid_objects_without_scalar_args(
+    tmp_path, grid, vgrid
+):
+    """Passing Grid/VGrid objects directly via hgrid_type/vgrid_type should not require
+    resolution, longitude_extent, latitude_extent, number_vertical_layers,
+    layer_thickness_ratio, or depth."""
+    expt = experiment(
+        date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+        mom_run_dir=tmp_path / "rundir",
+        mom_input_dir=tmp_path / "inputdir",
+        hgrid_type=grid,
+        vgrid_type=vgrid,
+    )
+
+    assert expt.longitude_extent == (-5.0, 5.0)
+    assert expt.latitude_extent == (0.0, 10.0)
+    assert expt.m6f_hgrid is grid
+    assert expt.m6f_vgrid is vgrid
+
+
+def test_experiment_requires_hgrid_scalars_when_no_grid_object(tmp_path):
+    """Without a Grid object, resolution/longitude_extent/latitude_extent are required
+    to generate an hgrid."""
+    with pytest.raises(AssertionError, match="resolution"):
+        experiment(
+            date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+            mom_run_dir=tmp_path / "rundir",
+            mom_input_dir=tmp_path / "inputdir",
+            number_vertical_layers=5,
+            layer_thickness_ratio=1,
+            depth=1000,
+        )
+
+
+def test_experiment_requires_vgrid_scalars_when_no_vgrid_object(tmp_path):
+    """Without a VGrid object, number_vertical_layers/layer_thickness_ratio/depth are
+    required to generate a vgrid."""
+    with pytest.raises(AssertionError, match="number_vertical_layers"):
+        experiment(
+            longitude_extent=[-5, 5],
+            latitude_extent=[0, 10],
+            date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+            resolution=0.1,
+            mom_run_dir=tmp_path / "rundir",
+            mom_input_dir=tmp_path / "inputdir",
+        )
+
+
+def _write_hgrid_with_bad_angle_calc(tmp_path, grid, angle_offset_degrees):
+    """Build a small hgrid via mom6_forge, inject an `angle_dx` discrepancy, and write
+    it to `tmp_path/inputdir/hgrid.nc`. Returns the input dir."""
+    ds = grid.supergrid.to_ds()
+    ds["angle_dx"] = ds["angle_dx"] + angle_offset_degrees
+    input_dir = tmp_path / "inputdir"
+    input_dir.mkdir()
+    ds.to_netcdf(input_dir / "hgrid.nc")
+    return input_dir
+
+
+def test_hgrid_property_raises_on_stale_angle_dx(tmp_path, grid, vgrid):
+    """A large angle_dx discrepancy discovered on a *lazy* hgrid.nc load (i.e. not
+    during __init__ itself) should hard-error, pointing at recalculate_rotation_angle.
+    """
+    input_dir = _write_hgrid_with_bad_angle_calc(
+        tmp_path, grid, angle_offset_degrees=45.0
+    )
+
+    with pytest.warns(UserWarning, match="recalculate_rotation_angle"):
+        expt = experiment(
+            date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+            mom_run_dir=tmp_path / "rundir",
+            mom_input_dir=input_dir,
+            hgrid_type="from_file",
+            vgrid_type=vgrid,
+        )
+
+
+def test_recalculate_rotation_angle_is_noop_for_consistent_grid(tmp_path, grid, vgrid):
+    """Calling recalculate_rotation_angle() on an already-consistent grid should
+    leave angle_dx unchanged."""
+    expt = experiment(
+        date_range=["2003-01-01 00:00:00", "2003-01-01 00:00:00"],
+        mom_run_dir=tmp_path / "rundir",
+        mom_input_dir=tmp_path / "inputdir",
+        hgrid_type=grid,
+        vgrid_type=vgrid,
+    )
+
+    before = expt.hgrid["angle_dx"].values.copy()
+    expt.recalculate_rotation_angle()
+    after = expt.hgrid["angle_dx"].values
+
+    np.testing.assert_allclose(before, after)


### PR DESCRIPTION
## Summary
- mom6_forge's `chl.py` (SeaWiFS chlorophyll interpolation, `interpolate_and_fill_seawifs`/`gen_chl_empty_dataset`) is being removed from mom6_forge.
- Move the full implementation into `regional_mom6/chl.py` as-is. Its dependencies (`Grid`, `Topo`, `utils.fill_missing_data`/`compute_subsampling_factor`, `mapping.regrid_with_subsampling`) are unaffected and continue to come from the mom6_forge package, same as `regional_mom6/regional_mom6.py` already does via the `grid.py`/`topo.py` re-export shims.

## Test plan
- [x] `from regional_mom6.chl import interpolate_and_fill_seawifs, gen_chl_empty_dataset` succeeds (mom6-regional-dev env, mom6_forge bumped to 0.3.0)
- [x] `black regional_mom6/chl.py` — no changes needed