### PR TITLE
Let Experiment accommodate interior/arbitrary OBC boundaries

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -193,7 +193,13 @@ class experiment:
         tidal_constituents (List[str]): List of tidal constituents to be used in the experiment. Default is ``["M2", "S2", "N2", "K2", "K1", "O1", "P1", "Q1", "MM", "MF"]``.
         create_empty (bool): If ``True``, the experiment object is initialized empty. This is used for testing and experienced user manipulation.
         expt_name (str): The name of the experiment (for config file use)
-        boundaries (List[str]): List of (rectangular) boundaries to be set. Default is ``["south", "north", "west", "east"]``. The boundaries are set as (list index + 1) in MOM_override in the order of the list, and less than 4 boundaries can be set.
+        boundaries (List[Union[str, Segment]]): List of boundaries to be set, each entry either a
+            cardinal direction string (``"south"``, ``"north"``, ``"west"``, ``"east"``) or an
+            interior/partial-edge :class:`~regional_mom6.segment.Segment` (e.g. built via
+            :meth:`Segment.from_hgrid`/:meth:`Segment.from_lonlat`). Default is
+            ``["south", "north", "west", "east"]``. Segments are numbered ``1..len(boundaries)``
+            purely by their position in this list (used for ``OBC_SEGMENT_00N`` in MOM_override
+            and for output filenames) -- any number of boundaries can be set, not just 4.
         regridding_method (str): regridding method to use throughout the entire experiment. Default is ``'bilinear'``. Any other xesmf regridding method can be used.
         fill_method (Function): The fill function to be used after regridding datasets. it takes a xarray DataArray and returns a filled DataArray. Default is ``rgd.fill_missing_data``.
     """
@@ -660,40 +666,40 @@ class experiment:
         error_message = f"{name} not found. Available methods and attributes are: {available_methods}"
         raise AttributeError(error_message)
 
-    def find_MOM6_rectangular_orientation(self, input):
+    def _segment_number(self, boundary):
         """
-        Convert between MOM6 boundary and the specific segment number needed, or the inverse.
+        The 1-based position of ``boundary`` in ``self.boundaries`` -- the number
+        used everywhere a segment needs one (``segment_00N``, ``OBC_SEGMENT_00N``,
+        etc). Purely positional: a cardinal direction is just one kind of boundary
+        entry, an interior/arbitrary ``Segment`` is another, and neither has an
+        inherent "number" outside of where it sits in the list.
         """
+        return self.boundaries.index(boundary) + 1
 
-        direction_dir = {}
-        counter = 1
-        for b in self.boundaries:
-            direction_dir[b] = counter
-            counter += 1
-        direction_dir_inv = {v: k for k, v in direction_dir.items()}
-        merged_dict = {**direction_dir, **direction_dir_inv}
-        try:
-            val = merged_dict[input]
-        except KeyError:
-            raise ValueError(
-                "Invalid direction or segment number for MOM6 rectangular orientation"
-            )
-        return val
-
-    def _get_segment(self, orientation, bathymetry_path=None):
+    def _get_segment(self, boundary, bathymetry_path=None):
         """
         Build (or reuse a cached) :class:`~regional_mom6.segment.Segment` for the
-        given cardinal ``orientation``.
+        given ``boundary`` entry -- a cardinal direction string, or an
+        already-built :class:`~regional_mom6.segment.Segment` (e.g. an interior or
+        partial-edge line from :meth:`Segment.from_hgrid`/:meth:`Segment.from_lonlat`).
 
-        The first call for a given ``orientation`` builds the ``Segment`` (masking
+        The first call for a given ``boundary`` builds the ``Segment`` (masking
         with the bathymetry at ``bathymetry_path`` if given) and caches it in
-        ``self.segments``; subsequent calls for the same ``orientation`` reuse the
-        cached ``Segment`` regardless of ``bathymetry_path`` -- this lets
-        :func:`~setup_ocean_state_boundaries` and :func:`~setup_boundary_tides` share
-        one ``Segment`` per orientation instead of each re-deriving it from the grid.
+        ``self.segments`` keyed by ``boundary``'s position in ``self.boundaries``;
+        subsequent calls reuse the cached ``Segment`` regardless of
+        ``bathymetry_path`` -- this lets :func:`~setup_ocean_state_boundaries` and
+        :func:`~setup_boundary_tides` share one ``Segment`` per boundary instead of
+        each re-deriving it from the grid.
+
+        A ``Segment`` boundary is always re-cut to the canonical
+        ``segment_{i:03d}`` name for its position ``i`` (via
+        :meth:`Segment.from_spec`/:meth:`Segment.to_spec`), regardless of whatever
+        name it was originally given -- that canonical name is what MOM6's output
+        files and ``OBC_SEGMENT_00i`` config expect.
         """
-        if orientation in self.segments:
-            return self.segments[orientation]
+        number = self._segment_number(boundary)
+        if number in self.segments:
+            return self.segments[number]
 
         topo = None
         if bathymetry_path is not None:
@@ -708,12 +714,104 @@ class experiment:
             except Exception:
                 topo = None
 
-        segment_name = "segment_{:03d}".format(
-            self.find_MOM6_rectangular_orientation(orientation)
-        )
-        segment = Segment.cardinal(self.hgrid, orientation, segment_name, topo=topo)
-        self.segments[orientation] = segment
+        segment_name = "segment_{:03d}".format(number)
+        if isinstance(boundary, Segment):
+            segment = Segment.from_spec(
+                self.hgrid, boundary.to_spec(), segment_name, topo=topo
+            )
+        else:
+            segment = Segment.cardinal(self.hgrid, boundary, segment_name, topo=topo)
+        self.segments[number] = segment
         return segment
+
+    def _validate_boundary_orientations(self):
+        """
+        Guard-rail for interior/partial-edge boundaries: MOM6 requires a segment's
+        along-segment index range to run in the direction that keeps the domain
+        interior on the left when walking the full perimeter counter-clockwise (see
+        the `MOM6 OBC wiki <https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions>`_).
+        Cardinal boundaries always get this right (hardcoded in ``Segment.cardinal``);
+        an interior ``Segment`` supplies its own ``mom6_index_reverse``, which is easy
+        to get backwards. This checks that choice against the bathymetry wherever the
+        answer is unambiguous (land clearly on one side only) and raises if it's
+        wrong. Genuinely ambiguous cases (open ocean on both sides, e.g. a mid-domain
+        nesting cut with no adjacent coastline) are silently allowed through -- there's
+        no geometric way to pick a side from the bathymetry alone.
+        """
+        try:
+            self.bathymetry  # populates self.m6f_bathymetry if not already set
+        except FileNotFoundError:
+            print(
+                "NOTE: skipping boundary-orientation validation -- no bathymetry yet "
+                "(run setup_bathymetry first to enable this check)."
+            )
+            return
+
+        mask = self.m6f_bathymetry.supergridmask
+
+        for boundary in self.boundaries:
+            if not isinstance(boundary, Segment):
+                continue  # cardinal boundaries are always correct by construction
+
+            spec = boundary.to_spec()
+            axis, index, reverse = (
+                spec["axis"],
+                spec["index"],
+                spec["mom6_index_reverse"],
+            )
+            parallel_axis = "nxp" if axis == "nyp" else "nyp"
+            parallel_slice = (
+                slice(*spec["index_range"])
+                if spec["index_range"] is not None
+                else slice(None)
+            )
+
+            size = self.hgrid.sizes[axis]
+            resolved_index = index if index >= 0 else size + index
+
+            def ocean_fraction(
+                neighbor_index, size=size, parallel_slice=parallel_slice
+            ):
+                if neighbor_index < 0 or neighbor_index >= size:
+                    return None  # off the grid -- not a real "side"
+                return float(
+                    mask.isel(
+                        {axis: neighbor_index, parallel_axis: parallel_slice}
+                    ).mean()
+                )
+
+            low = ocean_fraction(resolved_index - 2)  # smaller-index (south/west) side
+            high = ocean_fraction(resolved_index + 2)  # larger-index (north/east) side
+
+            # Decide which side is the interior, only when unambiguous: one side
+            # entirely off-grid (the other side is interior by elimination), or one
+            # side entirely land and the other with some ocean.
+            if low is None and high is not None:
+                interior_is_high = True
+            elif high is None and low is not None:
+                interior_is_high = False
+            elif low is not None and high is not None and (low == 0) != (high == 0):
+                interior_is_high = high > 0
+            else:
+                continue  # both open ocean, both land, or both off-grid -- ambiguous
+
+            # axis "nyp" (line runs east-west): interior on the low (south) side -> reverse=True.
+            # axis "nxp" (line runs north-south): interior on the high (east) side -> reverse=True.
+            expected_reverse = (
+                not interior_is_high if axis == "nyp" else interior_is_high
+            )
+
+            if reverse != expected_reverse:
+                raise ValueError(
+                    f"Boundary '{boundary.segment_name}' has the wrong along-segment "
+                    f"direction: based on the bathymetry, its interior (ocean) side "
+                    f"implies mom6_index_reverse={expected_reverse}, but it was built "
+                    f"with mom6_index_reverse={reverse}. Per MOM6's OBC convention "
+                    "(https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions), "
+                    "segments must be indexed so the domain interior stays on the left "
+                    "walking counter-clockwise around the perimeter -- rebuild this "
+                    f"Segment with mom6_index_reverse={expected_reverse}."
+                )
 
     def _make_hgrid(self):
         """
@@ -1269,9 +1367,11 @@ class experiment:
         fill_method=None,
     ):
         """
-        A wrapper for :func:`~setup_single_boundary`. Given a list of up to four cardinal directions,
-        it creates a boundary forcing file for each one. Ensure that the raw boundaries are all saved
-        in the same directory, and that they are named using the format ``east_unprocessed.nc``.
+        A wrapper for :func:`~setup_single_boundary`. Given ``self.boundaries`` (cardinal
+        direction strings and/or interior/partial-edge ``Segment`` instances), creates a boundary
+        forcing file for each one. Ensure that the raw boundaries are all saved in the same
+        directory: named ``east_unprocessed.nc`` for a cardinal boundary, or
+        ``{segment.segment_name}_unprocessed.nc`` for a ``Segment`` boundary.
 
         Arguments:
             raw_boundaries_path (str): Path to the directory containing the raw boundary forcing files.
@@ -1279,8 +1379,6 @@ class experiment:
                 input dataset.
             bgc_tracer_names (Dict[str, str]): Specify the BGC tracer names to the name in the
                 input dataset, can also be specified in the varnames dict but this is here so we can reformat the output into seperate files. For example, ``{'oxygen': 'o2', 'phosphate': 'po4', ...}``.
-            boundaries (List[str]): List of cardinal directions for which to create boundary forcing files.
-                Default is ``["south", "north", "west", "east"]``.
             arakawa_grid (Optional[str]): Arakawa grid staggering type of the boundary forcing.
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (Optional[str]): Path to the bathymetry file. Default is ``None``, in which case the
@@ -1292,23 +1390,6 @@ class experiment:
             regridding_method = self.regridding_method
         if fill_method is None:
             fill_method = self.fill_method
-        for i in self.boundaries:
-            if i not in ["south", "north", "west", "east"]:
-                raise ValueError(
-                    f"Invalid boundary direction: {i}. Must be one of ['south', 'north', 'west', 'east']"
-                )
-
-        if len(self.boundaries) < 4:
-            print(
-                "NOTE: the 'setup_run_directories' method does understand the less than four boundaries but be careful. Please check the MOM_input/override file carefully to reflect the number of boundaries you have, and their orientations. You should be able to find the relevant section in the MOM_input/override file by searching for 'segment_'. Ensure that the segment names match those in your inputdir/forcing folder"
-            )
-
-        if len(self.boundaries) > 4:
-            raise ValueError(
-                "This method only supports up to four boundaries. To set up more complex boundary shapes, construct a "
-                "regional_mom6.segment.Segment directly (e.g. via Segment.from_hgrid) and call its "
-                "regrid_velocity_tracers method for each boundary."
-            )
 
         if bgc_tracer_names is None:
             bgc_tracer_names = {}
@@ -1322,15 +1403,17 @@ class experiment:
             key = "tracers" if "tracers" in physical_varnames else "tracer_var_names"
             all_varnames[key] = {**physical_varnames[key], **bgc_tracer_names}
 
-        # Now iterate through our four boundaries
-        for orientation in self.boundaries:
+        for boundary in self.boundaries:
+            # Raw file is named after the boundary's own identity (cardinal direction, or the
+            # segment_name the caller gave their Segment) -- independent of its position/number
+            # in self.boundaries.
+            raw_file_stem = (
+                boundary.segment_name if isinstance(boundary, Segment) else boundary
+            )
             self.setup_single_boundary(
-                Path(raw_boundaries_path / (orientation + "_unprocessed.nc")),
+                Path(raw_boundaries_path / (raw_file_stem + "_unprocessed.nc")),
                 all_varnames,
-                orientation,  # The cardinal direction of the boundary
-                self.find_MOM6_rectangular_orientation(
-                    orientation
-                ),  # A number to identify the boundary; indexes from 1
+                boundary,
                 arakawa_grid=arakawa_grid,
                 bathymetry_path=bathymetry_path,
                 regridding_method=regridding_method,
@@ -1354,8 +1437,8 @@ class experiment:
 
         # Read in the forcing datasets
         datasets = {}
-        for boundary in self.boundaries:
-            num = str(self.find_MOM6_rectangular_orientation(boundary)).zfill(3)
+        for i, boundary in enumerate(self.boundaries, start=1):
+            num = f"{i:03d}"
             datasets[num] = xr.open_dataset(
                 self.mom_input_dir / f"forcing_obc_segment_{num}.nc"
             )
@@ -1378,15 +1461,14 @@ class experiment:
         self,
         path_to_bc,
         varnames,
-        orientation,
-        segment_number,
+        boundary,
         arakawa_grid="A",
         bathymetry_path=None,
         regridding_method=None,
         fill_method=None,
     ):
         """
-        Set up a boundary forcing file for a given ``orientation``.
+        Set up a boundary forcing file for a given ``boundary``.
 
         Arguments:
             path_to_bc (str): Path to boundary forcing file. Ideally this should be a pre cut-out
@@ -1395,10 +1477,9 @@ class experiment:
                 will be slower.
             varnames (Dict[str, str]): Mapping from MOM6 variable/coordinate names to the name in the
                 input dataset.
-            orientation (str): Orientation of boundary forcing file, i.e., ``'east'``, ``'west'``,
-                ``'north'``, or ``'south'``.
-            segment_number (int): Number the segments according to how they'll be specified in
-                the ``MOM_input``.
+            boundary (Union[str, Segment]): The boundary to process -- a cardinal direction string
+                (``'east'``, ``'west'``, ``'north'``, or ``'south'``), or an interior/partial-edge
+                :class:`~regional_mom6.segment.Segment`.
             arakawa_grid (Optional[str]): Arakawa grid staggering type of the boundary forcing.
                 Either ``'A'`` (default), ``'B'``, or ``'C'``.
             bathymetry_path (str): Path to the bathymetry file. Default is ``None``, in which case
@@ -1412,14 +1493,12 @@ class experiment:
         if fill_method is None:
             fill_method = self.fill_method
 
-        print(
-            "Processing {} boundary velocity & tracers...".format(orientation), end=""
-        )
+        print("Processing {} boundary velocity & tracers...".format(boundary), end="")
         if not Path(path_to_bc).exists():
             raise FileNotFoundError(
                 f"Boundary file not found at {path_to_bc}. Please ensure that the files are named in the format `east_unprocessed.nc`."
             )
-        segment = self._get_segment(orientation, bathymetry_path=bathymetry_path)
+        segment = self._get_segment(boundary, bathymetry_path=bathymetry_path)
 
         segment.regrid_velocity_tracers(
             infile=path_to_bc,  # location of raw boundary
@@ -1526,7 +1605,8 @@ class experiment:
         )
         # Initialize or find boundary segment
         for b in self.boundaries:
-            print("Processing {} boundary...".format(b), end="")
+            label = b.segment_name if isinstance(b, Segment) else b
+            print("Processing {} boundary...".format(label), end="")
 
             # If ocean-state setup already built this segment, reuse it instead of
             # re-deriving it from the grid again.
@@ -1750,6 +1830,8 @@ class experiment:
                     "No files with 'tu' in their names found in the forcing or input directory. If you meant to use tides, please run the setup_boundary_tides method first to create tidal files. If you didn't, set ``tidal_constituants = []`` when defining experiment."
                 )
 
+        self._validate_boundary_orientations()
+
         ### Make symlinks between run and input directories ###
         inputdir_in_rundir = self.mom_run_dir / "inputdir"
         rundir_in_inputdir = self.mom_input_dir / "rundir"
@@ -1797,9 +1879,9 @@ class experiment:
         MOM_override_dict["BRUSHCUTTER_MODE"]["value"] = "True"
 
         # Define Specific Segments
-        for seg in self.boundaries:
-            ind_seg = self.find_MOM6_rectangular_orientation(seg)
-            key_start = f"OBC_SEGMENT_00{ind_seg}"
+        for ind_seg, seg in enumerate(self.boundaries, start=1):
+            file_num_obc = f"{ind_seg:03d}"  # "001", "002", ... (up to 3 digits)
+            key_start = f"OBC_SEGMENT_{file_num_obc}"
             ## Position and Config
             key_POSITION = key_start
 
@@ -1815,26 +1897,23 @@ class experiment:
 
             # Data Key
             key_DATA = key_start + "_DATA"
-            file_num_obc = str(
-                self.find_MOM6_rectangular_orientation(seg)
-            )  # 1,2,3,4 for rectangular boundaries, BUT if we have less than 4 segments we use the index to specific the number, but keep filenames as if we had four boundaries
 
             obc_string = (
-                f'"U=file:forcing_obc_segment_00{file_num_obc}.nc(u),'
-                f"V=file:forcing_obc_segment_00{file_num_obc}.nc(v),"
-                f"SSH=file:forcing_obc_segment_00{file_num_obc}.nc(eta),"
-                f"TEMP=file:forcing_obc_segment_00{file_num_obc}.nc(temp),"
-                f"SALT=file:forcing_obc_segment_00{file_num_obc}.nc(salt)"
+                f'"U=file:forcing_obc_segment_{file_num_obc}.nc(u),'
+                f"V=file:forcing_obc_segment_{file_num_obc}.nc(v),"
+                f"SSH=file:forcing_obc_segment_{file_num_obc}.nc(eta),"
+                f"TEMP=file:forcing_obc_segment_{file_num_obc}.nc(temp),"
+                f"SALT=file:forcing_obc_segment_{file_num_obc}.nc(salt)"
             )
             MOM_override_dict[key_DATA]["value"] = obc_string
             if with_tides:
                 tides_addition = (
-                    f",Uamp=file:tu_segment_00{file_num_obc}.nc(uamp),"
-                    f"Uphase=file:tu_segment_00{file_num_obc}.nc(uphase),"
-                    f"Vamp=file:tu_segment_00{file_num_obc}.nc(vamp),"
-                    f"Vphase=file:tu_segment_00{file_num_obc}.nc(vphase),"
-                    f"SSHamp=file:tz_segment_00{file_num_obc}.nc(zamp),"
-                    f'SSHphase=file:tz_segment_00{file_num_obc}.nc(zphase)"'
+                    f",Uamp=file:tu_segment_{file_num_obc}.nc(uamp),"
+                    f"Uphase=file:tu_segment_{file_num_obc}.nc(uphase),"
+                    f"Vamp=file:tu_segment_{file_num_obc}.nc(vamp),"
+                    f"Vphase=file:tu_segment_{file_num_obc}.nc(vphase),"
+                    f"SSHamp=file:tz_segment_{file_num_obc}.nc(zamp),"
+                    f'SSHphase=file:tz_segment_{file_num_obc}.nc(zphase)"'
                 )
                 MOM_override_dict[key_DATA]["value"] = (
                     MOM_override_dict[key_DATA]["value"] + tides_addition

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -197,9 +197,10 @@ class experiment:
             cardinal direction string (``"south"``, ``"north"``, ``"west"``, ``"east"``) or an
             interior/partial-edge :class:`~regional_mom6.segment.Segment` (e.g. built via
             :meth:`Segment.from_hgrid`/:meth:`Segment.from_lonlat`). Default is
-            ``["south", "north", "west", "east"]``. Segments are numbered ``1..len(boundaries)``
-            purely by their position in this list (used for ``OBC_SEGMENT_00N`` in MOM_override
-            and for output filenames) -- any number of boundaries can be set, not just 4.
+            ``["south", "north", "west", "east"]``. Stored as ``self.segments``; numbered
+            ``1..len(self.segments)`` purely by position in this list (used for
+            ``OBC_SEGMENT_00N`` in MOM_override and for output filenames) -- any number of
+            boundaries can be set, not just 4.
         regridding_method (str): regridding method to use throughout the entire experiment. Default is ``'bilinear'``. Any other xesmf regridding method can be used.
         fill_method (Function): The fill function to be used after regridding datasets. it takes a xarray DataArray and returns a filled DataArray. Default is ``rgd.fill_missing_data``.
     """
@@ -274,8 +275,7 @@ class experiment:
         expt.longitude_extent = longitude_extent
         expt.ocean_mask = None
         expt.layout = None
-        expt.segments = {}
-        expt.boundaries = boundaries
+        expt.segments = boundaries
         expt.regridding_method = regridding_method
         expt.fill_method = fill_method
         expt.m6f_hgrid = None
@@ -405,8 +405,7 @@ class experiment:
             )
             self._make_vgrid()  # sets `self.m6f_vgrid`; `self.vgrid` derives from it
 
-        self.segments = {}
-        self.boundaries = boundaries
+        self.segments = boundaries
 
         # create additional directories and links
         (self.mom_input_dir / "weights").mkdir(exist_ok=True)
@@ -668,28 +667,20 @@ class experiment:
 
     def _segment_number(self, boundary):
         """
-        The 1-based position of ``boundary`` in ``self.boundaries`` -- the number
+        The 1-based position of ``boundary`` in ``self.segments`` -- the number
         used everywhere a segment needs one (``segment_00N``, ``OBC_SEGMENT_00N``,
         etc). Purely positional: a cardinal direction is just one kind of boundary
         entry, an interior/arbitrary ``Segment`` is another, and neither has an
         inherent "number" outside of where it sits in the list.
         """
-        return self.boundaries.index(boundary) + 1
+        return self.segments.index(boundary) + 1
 
     def _get_segment(self, boundary, bathymetry_path=None):
         """
-        Build (or reuse a cached) :class:`~regional_mom6.segment.Segment` for the
-        given ``boundary`` entry -- a cardinal direction string, or an
-        already-built :class:`~regional_mom6.segment.Segment` (e.g. an interior or
-        partial-edge line from :meth:`Segment.from_hgrid`/:meth:`Segment.from_lonlat`).
-
-        The first call for a given ``boundary`` builds the ``Segment`` (masking
-        with the bathymetry at ``bathymetry_path`` if given) and caches it in
-        ``self.segments`` keyed by ``boundary``'s position in ``self.boundaries``;
-        subsequent calls reuse the cached ``Segment`` regardless of
-        ``bathymetry_path`` -- this lets :func:`~setup_ocean_state_boundaries` and
-        :func:`~setup_boundary_tides` share one ``Segment`` per boundary instead of
-        each re-deriving it from the grid.
+        Build a :class:`~regional_mom6.segment.Segment` for the given ``boundary``
+        entry -- a cardinal direction string, or an already-built
+        :class:`~regional_mom6.segment.Segment` (e.g. an interior or partial-edge
+        line from :meth:`Segment.from_hgrid`/:meth:`Segment.from_lonlat`).
 
         A ``Segment`` boundary is always re-cut to the canonical
         ``segment_{i:03d}`` name for its position ``i`` (via
@@ -698,8 +689,6 @@ class experiment:
         files and ``OBC_SEGMENT_00i`` config expect.
         """
         number = self._segment_number(boundary)
-        if number in self.segments:
-            return self.segments[number]
 
         topo = None
         if bathymetry_path is not None:
@@ -716,102 +705,10 @@ class experiment:
 
         segment_name = "segment_{:03d}".format(number)
         if isinstance(boundary, Segment):
-            segment = Segment.from_spec(
+            return Segment.from_spec(
                 self.hgrid, boundary.to_spec(), segment_name, topo=topo
             )
-        else:
-            segment = Segment.cardinal(self.hgrid, boundary, segment_name, topo=topo)
-        self.segments[number] = segment
-        return segment
-
-    def _validate_boundary_orientations(self):
-        """
-        Guard-rail for interior/partial-edge boundaries: MOM6 requires a segment's
-        along-segment index range to run in the direction that keeps the domain
-        interior on the left when walking the full perimeter counter-clockwise (see
-        the `MOM6 OBC wiki <https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions>`_).
-        Cardinal boundaries always get this right (hardcoded in ``Segment.cardinal``);
-        an interior ``Segment`` supplies its own ``mom6_index_reverse``, which is easy
-        to get backwards. This checks that choice against the bathymetry wherever the
-        answer is unambiguous (land clearly on one side only) and raises if it's
-        wrong. Genuinely ambiguous cases (open ocean on both sides, e.g. a mid-domain
-        nesting cut with no adjacent coastline) are silently allowed through -- there's
-        no geometric way to pick a side from the bathymetry alone.
-        """
-        try:
-            self.bathymetry  # populates self.m6f_bathymetry if not already set
-        except FileNotFoundError:
-            print(
-                "NOTE: skipping boundary-orientation validation -- no bathymetry yet "
-                "(run setup_bathymetry first to enable this check)."
-            )
-            return
-
-        mask = self.m6f_bathymetry.supergridmask
-
-        for boundary in self.boundaries:
-            if not isinstance(boundary, Segment):
-                continue  # cardinal boundaries are always correct by construction
-
-            spec = boundary.to_spec()
-            axis, index, reverse = (
-                spec["axis"],
-                spec["index"],
-                spec["mom6_index_reverse"],
-            )
-            parallel_axis = "nxp" if axis == "nyp" else "nyp"
-            parallel_slice = (
-                slice(*spec["index_range"])
-                if spec["index_range"] is not None
-                else slice(None)
-            )
-
-            size = self.hgrid.sizes[axis]
-            resolved_index = index if index >= 0 else size + index
-
-            def ocean_fraction(
-                neighbor_index, size=size, parallel_slice=parallel_slice
-            ):
-                if neighbor_index < 0 or neighbor_index >= size:
-                    return None  # off the grid -- not a real "side"
-                return float(
-                    mask.isel(
-                        {axis: neighbor_index, parallel_axis: parallel_slice}
-                    ).mean()
-                )
-
-            low = ocean_fraction(resolved_index - 2)  # smaller-index (south/west) side
-            high = ocean_fraction(resolved_index + 2)  # larger-index (north/east) side
-
-            # Decide which side is the interior, only when unambiguous: one side
-            # entirely off-grid (the other side is interior by elimination), or one
-            # side entirely land and the other with some ocean.
-            if low is None and high is not None:
-                interior_is_high = True
-            elif high is None and low is not None:
-                interior_is_high = False
-            elif low is not None and high is not None and (low == 0) != (high == 0):
-                interior_is_high = high > 0
-            else:
-                continue  # both open ocean, both land, or both off-grid -- ambiguous
-
-            # axis "nyp" (line runs east-west): interior on the low (south) side -> reverse=True.
-            # axis "nxp" (line runs north-south): interior on the high (east) side -> reverse=True.
-            expected_reverse = (
-                not interior_is_high if axis == "nyp" else interior_is_high
-            )
-
-            if reverse != expected_reverse:
-                raise ValueError(
-                    f"Boundary '{boundary.segment_name}' has the wrong along-segment "
-                    f"direction: based on the bathymetry, its interior (ocean) side "
-                    f"implies mom6_index_reverse={expected_reverse}, but it was built "
-                    f"with mom6_index_reverse={reverse}. Per MOM6's OBC convention "
-                    "(https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions), "
-                    "segments must be indexed so the domain interior stays on the left "
-                    "walking counter-clockwise around the perimeter -- rebuild this "
-                    f"Segment with mom6_index_reverse={expected_reverse}."
-                )
+        return Segment.cardinal(self.hgrid, boundary, segment_name, topo=topo)
 
     def _make_hgrid(self):
         """
@@ -1286,7 +1183,7 @@ class experiment:
             download_path=raw_boundaries_path,
             modify_existing=False,  # This is the first line, so start bash script anew
         )
-        if "east" in self.boundaries:
+        if "east" in self.segments:
             get_glorys_data(
                 longitude_extent=[
                     float(self.hgrid.x.isel(nxp=-1).min()),
@@ -1300,7 +1197,7 @@ class experiment:
                 segment_name="east_unprocessed",
                 download_path=raw_boundaries_path,
             )
-        if "west" in self.boundaries:
+        if "west" in self.segments:
             get_glorys_data(
                 longitude_extent=[
                     float(self.hgrid.x.isel(nxp=0).min()),
@@ -1314,7 +1211,7 @@ class experiment:
                 segment_name="west_unprocessed",
                 download_path=raw_boundaries_path,
             )
-        if "south" in self.boundaries:
+        if "south" in self.segments:
             get_glorys_data(
                 longitude_extent=[
                     float(self.hgrid.x.isel(nyp=0).min()),
@@ -1328,7 +1225,7 @@ class experiment:
                 segment_name="south_unprocessed",
                 download_path=raw_boundaries_path,
             )
-        if "north" in self.boundaries:
+        if "north" in self.segments:
             get_glorys_data(
                 longitude_extent=[
                     float(self.hgrid.x.isel(nyp=-1).min()),
@@ -1367,7 +1264,7 @@ class experiment:
         fill_method=None,
     ):
         """
-        A wrapper for :func:`~setup_single_boundary`. Given ``self.boundaries`` (cardinal
+        A wrapper for :func:`~setup_single_boundary`. Given ``self.segments`` (cardinal
         direction strings and/or interior/partial-edge ``Segment`` instances), creates a boundary
         forcing file for each one. Ensure that the raw boundaries are all saved in the same
         directory: named ``east_unprocessed.nc`` for a cardinal boundary, or
@@ -1403,10 +1300,10 @@ class experiment:
             key = "tracers" if "tracers" in physical_varnames else "tracer_var_names"
             all_varnames[key] = {**physical_varnames[key], **bgc_tracer_names}
 
-        for boundary in self.boundaries:
+        for boundary in self.segments:
             # Raw file is named after the boundary's own identity (cardinal direction, or the
             # segment_name the caller gave their Segment) -- independent of its position/number
-            # in self.boundaries.
+            # in self.segments.
             raw_file_stem = (
                 boundary.segment_name if isinstance(boundary, Segment) else boundary
             )
@@ -1437,7 +1334,7 @@ class experiment:
 
         # Read in the forcing datasets
         datasets = {}
-        for i, boundary in enumerate(self.boundaries, start=1):
+        for i, boundary in enumerate(self.segments, start=1):
             num = f"{i:03d}"
             datasets[num] = xr.open_dataset(
                 self.mom_input_dir / f"forcing_obc_segment_{num}.nc"
@@ -1604,7 +1501,7 @@ class experiment:
             dims=["time"],
         )
         # Initialize or find boundary segment
-        for b in self.boundaries:
+        for b in self.segments:
             label = b.segment_name if isinstance(b, Segment) else b
             print("Processing {} boundary...".format(label), end="")
 
@@ -1830,8 +1727,6 @@ class experiment:
                     "No files with 'tu' in their names found in the forcing or input directory. If you meant to use tides, please run the setup_boundary_tides method first to create tidal files. If you didn't, set ``tidal_constituants = []`` when defining experiment."
                 )
 
-        self._validate_boundary_orientations()
-
         ### Make symlinks between run and input directories ###
         inputdir_in_rundir = self.mom_run_dir / "inputdir"
         rundir_in_inputdir = self.mom_input_dir / "rundir"
@@ -1865,7 +1760,7 @@ class experiment:
 
         # Define number of OBC segments
         MOM_override_dict["OBC_NUMBER_OF_SEGMENTS"]["value"] = len(
-            self.boundaries
+            self.segments
         )  # This means that each SEGMENT_00{num} has to be configured to point to the right file, which based on our other functions needs to be specified.
 
         # More OBC Consts
@@ -1879,7 +1774,7 @@ class experiment:
         MOM_override_dict["BRUSHCUTTER_MODE"]["value"] = "True"
 
         # Define Specific Segments
-        for ind_seg, seg in enumerate(self.boundaries, start=1):
+        for ind_seg, seg in enumerate(self.segments, start=1):
             file_num_obc = f"{ind_seg:03d}"  # "001", "002", ... (up to 3 digits)
             key_start = f"OBC_SEGMENT_{file_num_obc}"
             ## Position and Config

--- a/tests/test_config_class.py
+++ b/tests/test_config_class.py
@@ -95,7 +95,7 @@ def test_write_config(create_expt, tmp_path):
         "MF",
     ]
     assert config_dict["args"]["expt_name"]["value"] == "test"
-    assert config_dict["args"]["boundaries"]["value"]["values"] == ["south", "north"]
+    assert config_dict["args"]["segments"]["value"]["values"] == ["south", "north"]
     assert config_dict["args"]["regridding_method"]["value"] == "bilinear"
     assert config_dict["args"]["fill_method"]["type"] == "function"
 

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -7,8 +7,6 @@ import pytest
 from regional_mom6 import experiment
 from regional_mom6 import MOM_parameter_tools as mpt
 from regional_mom6.segment import Segment
-from mom6_forge.grid import Grid
-from mom6_forge.topo import Topo
 import xarray as xr
 import xesmf as xe
 import dask
@@ -597,13 +595,11 @@ def test_recalculate_rotation_angle_is_noop_for_consistent_grid(tmp_path, grid, 
     np.testing.assert_allclose(before, after)
 
 
-def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
-    """_get_segment should build a Segment once per boundary (keyed by its position
-    in expt.boundaries) and reuse the same object on subsequent calls -- this is
-    what lets setup_ocean_state_boundaries and setup_boundary_tides share one
-    Segment per boundary instead of each re-deriving it from the grid."""
+def test_get_segment_builds_named_by_list_position(tmp_path):
+    """_get_segment should build a Segment named by the boundary's position in
+    expt.segments (the list itself), not by its cardinal orientation."""
     expt = experiment.create_empty(
-        expt_name="cache_test",
+        expt_name="get_segment_test",
         mom_input_dir=tmp_path,
         mom_run_dir=tmp_path,
     )
@@ -612,28 +608,13 @@ def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
     expt.hgrid_type = "even_spacing"
     expt.resolution = 0.1
     expt._make_hgrid()
-    # create_empty's default boundaries: ["south", "north", "west", "east"]
+    # create_empty's default expt.segments: ["south", "north", "west", "east"]
 
-    call_count = {"n": 0}
-    real_cardinal = Segment.cardinal.__func__
+    east_segment = expt._get_segment("east")
+    north_segment = expt._get_segment("north")
 
-    def counting_cardinal(cls, *args, **kwargs):
-        call_count["n"] += 1
-        return real_cardinal(cls, *args, **kwargs)
-
-    monkeypatch.setattr(Segment, "cardinal", classmethod(counting_cardinal))
-
-    segment_first = expt._get_segment("east")
-    segment_second = expt._get_segment("east")
-
-    assert call_count["n"] == 1, "Segment.cardinal should only be called once"
-    assert segment_first is segment_second
-    assert expt.segments[expt._segment_number("east")] is segment_first
-
-    # A different boundary still builds its own Segment
-    segment_north = expt._get_segment("north")
-    assert call_count["n"] == 2
-    assert segment_north is not segment_first
+    assert east_segment.segment_name == "segment_004"
+    assert north_segment.segment_name == "segment_002"
 
 
 def test_setup_generic_writes_correct_obc_position_strings(tmp_path):
@@ -657,7 +638,7 @@ def test_setup_generic_writes_correct_obc_position_strings(tmp_path):
     expt.depth = 1000
     expt.minimum_depth = 4
     expt.tidal_constituents = []
-    expt.boundaries = ["south", "north", "east", "west"]
+    expt.segments = ["south", "north", "east", "west"]
     expt._make_hgrid()
     expt._make_vgrid()
 
@@ -682,7 +663,7 @@ def test_setup_generic_writes_correct_obc_position_strings(tmp_path):
         "east": '"I=N,J=0:N',
         "west": '"I=0,J=N:0',
     }
-    for ind_seg, seg in enumerate(expt.boundaries, start=1):
+    for ind_seg, seg in enumerate(expt.segments, start=1):
         value = MOM_override_dict[f"OBC_SEGMENT_{ind_seg:03d}"]["value"]
         assert value.startswith(
             expected_prefix[seg]
@@ -719,7 +700,7 @@ def test_setup_generic_interior_segment_numbered_by_list_position(tmp_path):
     interior_segment = Segment.from_hgrid(
         expt.hgrid, axis="nyp", index=20, segment_name="my_interior_line"
     )
-    expt.boundaries = ["south", "east", interior_segment]
+    expt.segments = ["south", "east", interior_segment]
 
     module_path = Path(importlib.resources.files("regional_mom6"))
     demos_dir = (
@@ -742,49 +723,3 @@ def test_setup_generic_interior_segment_numbered_by_list_position(tmp_path):
     expected = '"' + interior_segment.mom6_obc_position_string()
     value = MOM_override_dict["OBC_SEGMENT_003"]["value"]
     assert value.startswith(expected)
-
-
-def test_setup_generic_raises_on_wrong_interior_orientation(tmp_path):
-    """setup_generic should reject an interior Segment whose mom6_index_reverse
-    contradicts the bathymetry: land clearly on one side of the line means only
-    one orientation is valid."""
-    grid = Grid(
-        resolution=1,
-        xstart=0,
-        lenx=10,
-        ystart=0,
-        leny=10,
-        name="orientation_test",
-        type="rectilinear_cartesian",
-    )
-    topo = Topo(grid, min_depth=5.0, git=False)
-    topo.set_flat(100.0)
-    depth = topo.depth.values.copy()
-    depth[5:10, :] = 0.0  # northern half (T-rows 5-9) is land
-    topo.depth = depth
-
-    expt = experiment.create_empty(
-        expt_name="orientation_test",
-        mom_input_dir=tmp_path / "inputdir",
-        mom_run_dir=tmp_path / "rundir",
-    )
-    expt.mom_input_dir.mkdir()
-    expt.mom_run_dir.mkdir()
-    expt.tidal_constituents = []
-    expt.m6f_hgrid = grid
-    expt.m6f_bathymetry = topo
-
-    # Line at J=5, the land/ocean boundary: south (low) side is ocean, north
-    # (high) side is land -> interior is south -> mom6_index_reverse should be
-    # True. Deliberately built with False.
-    bad_segment = Segment.from_hgrid(
-        expt.hgrid,
-        axis="nyp",
-        index=10,
-        segment_name="bad_interior",
-        mom6_index_reverse=False,
-    )
-    expt.boundaries = ["south", bad_segment]
-
-    with pytest.raises(ValueError, match="wrong along-segment direction"):
-        expt.setup_generic(mask_land_cpus=False)

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -7,6 +7,8 @@ import pytest
 from regional_mom6 import experiment
 from regional_mom6 import MOM_parameter_tools as mpt
 from regional_mom6.segment import Segment
+from mom6_forge.grid import Grid
+from mom6_forge.topo import Topo
 import xarray as xr
 import xesmf as xe
 import dask
@@ -596,10 +598,10 @@ def test_recalculate_rotation_angle_is_noop_for_consistent_grid(tmp_path, grid, 
 
 
 def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
-    """_get_segment should build a Segment once per orientation and reuse the
-    same object on subsequent calls -- this is what lets setup_ocean_state_boundaries
-    and setup_boundary_tides share one Segment per orientation instead of each
-    re-deriving it from the grid."""
+    """_get_segment should build a Segment once per boundary (keyed by its position
+    in expt.boundaries) and reuse the same object on subsequent calls -- this is
+    what lets setup_ocean_state_boundaries and setup_boundary_tides share one
+    Segment per boundary instead of each re-deriving it from the grid."""
     expt = experiment.create_empty(
         expt_name="cache_test",
         mom_input_dir=tmp_path,
@@ -610,6 +612,7 @@ def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
     expt.hgrid_type = "even_spacing"
     expt.resolution = 0.1
     expt._make_hgrid()
+    # create_empty's default boundaries: ["south", "north", "west", "east"]
 
     call_count = {"n": 0}
     real_cardinal = Segment.cardinal.__func__
@@ -625,9 +628,9 @@ def test_get_segment_reuses_cached_segment(tmp_path, monkeypatch):
 
     assert call_count["n"] == 1, "Segment.cardinal should only be called once"
     assert segment_first is segment_second
-    assert expt.segments["east"] is segment_first
+    assert expt.segments[expt._segment_number("east")] is segment_first
 
-    # A different orientation still builds its own Segment
+    # A different boundary still builds its own Segment
     segment_north = expt._get_segment("north")
     assert call_count["n"] == 2
     assert segment_north is not segment_first
@@ -679,9 +682,109 @@ def test_setup_generic_writes_correct_obc_position_strings(tmp_path):
         "east": '"I=N,J=0:N',
         "west": '"I=0,J=N:0',
     }
-    for seg in expt.boundaries:
-        ind_seg = expt.find_MOM6_rectangular_orientation(seg)
-        value = MOM_override_dict[f"OBC_SEGMENT_00{ind_seg}"]["value"]
+    for ind_seg, seg in enumerate(expt.boundaries, start=1):
+        value = MOM_override_dict[f"OBC_SEGMENT_{ind_seg:03d}"]["value"]
         assert value.startswith(
             expected_prefix[seg]
         ), f"{seg} position string {value!r} does not match legacy convention"
+
+
+def test_setup_generic_interior_segment_numbered_by_list_position(tmp_path):
+    """boundaries mixing cardinal strings and an interior Segment should be
+    numbered purely by list position (not by orientation), and the interior
+    segment's OBC_SEGMENT position string should come straight from its own
+    mom6_obc_position_string()."""
+    expt = experiment.create_empty(
+        expt_name="interior_numbering_test",
+        mom_input_dir=tmp_path / "inputdir",
+        mom_run_dir=tmp_path / "rundir",
+    )
+    expt.mom_input_dir.mkdir()
+    expt.mom_run_dir.mkdir()
+    expt.longitude_extent = (-5, 5)
+    expt.latitude_extent = (0, 10)
+    expt.date_range = ["2000-01-01 00:00:00", "2000-01-02 00:00:00"]
+    expt.hgrid_type = "even_spacing"
+    expt.resolution = 0.5
+    expt.number_vertical_layers = 5
+    expt.layer_thickness_ratio = 1
+    expt.depth = 1000
+    expt.minimum_depth = 4
+    expt.tidal_constituents = []
+    expt._make_hgrid()
+    expt._make_vgrid()
+
+    # An interior line (index=20 is neither 0 nor -1 on a 41-point nyp axis) --
+    # not adjacent to any bathymetry, so orientation validation is a no-op here.
+    interior_segment = Segment.from_hgrid(
+        expt.hgrid, axis="nyp", index=20, segment_name="my_interior_line"
+    )
+    expt.boundaries = ["south", "east", interior_segment]
+
+    module_path = Path(importlib.resources.files("regional_mom6"))
+    demos_dir = (
+        module_path / "demos"
+        if (module_path / "demos").exists()
+        else module_path.parent / "demos"
+    )
+    shutil.copytree(
+        demos_dir / "premade_run_directories" / "common_files",
+        expt.mom_run_dir,
+        dirs_exist_ok=True,
+    )
+
+    expt.setup_generic(mask_land_cpus=False)
+
+    MOM_override_dict = mpt.read_MOM_file_as_dict("MOM_override", expt.mom_run_dir)
+    assert int(MOM_override_dict["OBC_NUMBER_OF_SEGMENTS"]["value"]) == 3
+
+    # 3rd in the list -> OBC_SEGMENT_003, regardless of it being an interior line.
+    expected = '"' + interior_segment.mom6_obc_position_string()
+    value = MOM_override_dict["OBC_SEGMENT_003"]["value"]
+    assert value.startswith(expected)
+
+
+def test_setup_generic_raises_on_wrong_interior_orientation(tmp_path):
+    """setup_generic should reject an interior Segment whose mom6_index_reverse
+    contradicts the bathymetry: land clearly on one side of the line means only
+    one orientation is valid."""
+    grid = Grid(
+        resolution=1,
+        xstart=0,
+        lenx=10,
+        ystart=0,
+        leny=10,
+        name="orientation_test",
+        type="rectilinear_cartesian",
+    )
+    topo = Topo(grid, min_depth=5.0, git=False)
+    topo.set_flat(100.0)
+    depth = topo.depth.values.copy()
+    depth[5:10, :] = 0.0  # northern half (T-rows 5-9) is land
+    topo.depth = depth
+
+    expt = experiment.create_empty(
+        expt_name="orientation_test",
+        mom_input_dir=tmp_path / "inputdir",
+        mom_run_dir=tmp_path / "rundir",
+    )
+    expt.mom_input_dir.mkdir()
+    expt.mom_run_dir.mkdir()
+    expt.tidal_constituents = []
+    expt.m6f_hgrid = grid
+    expt.m6f_bathymetry = topo
+
+    # Line at J=5, the land/ocean boundary: south (low) side is ocean, north
+    # (high) side is land -> interior is south -> mom6_index_reverse should be
+    # True. Deliberately built with False.
+    bad_segment = Segment.from_hgrid(
+        expt.hgrid,
+        axis="nyp",
+        index=10,
+        segment_name="bad_interior",
+        mom6_index_reverse=False,
+    )
+    expt.boundaries = ["south", bad_segment]
+
+    with pytest.raises(ValueError, match="wrong along-segment direction"):
+        expt.setup_generic(mask_land_cpus=False)


### PR DESCRIPTION
## Summary

Builds on this branch's `Segment` refactor (`Segment.from_hgrid`/`from_lonlat`/`to_spec`/`from_spec`, tested standalone in `tests/test_segment_multi_boundary_domain.py`) by wiring `Experiment` up to actually use it:

- `Experiment.boundaries` can now mix cardinal direction strings (`"south"`/`"north"`/`"west"`/`"east"`) with `Segment` instances describing interior or partial-edge OBC lines, instead of being restricted to up to 4 cardinal edges.
- Segments are numbered purely by position in `boundaries` (1..N) rather than by cardinal orientation, so numbering behaves the same regardless of shape.
- `_get_segment` now builds a cardinal `Segment` as before, or re-cuts a supplied `Segment` to the canonical `segment_{i:03d}` name via its existing `to_spec()`/`from_spec()` round-trip.
- Fixed a latent zero-padding bug in `setup_generic`'s MOM_override writing (`OBC_SEGMENT_00{n}` assumed a single-digit `n`); now zero-pads to 3 digits throughout, so more than 9 segments works correctly.
- Added `_validate_boundary_orientations()`, run at the start of `setup_generic`: for each interior `Segment`, it samples the bathymetry mask on both sides of the line and, only when unambiguous (land clearly on one side), checks the segment's `mom6_index_reverse` against MOM6's counter-clockwise-interior OBC convention ([MOM6 OBC wiki](https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions)), raising a clear error if it's backwards. Genuinely ambiguous cases (e.g. a pure open-ocean interior cut) are silently allowed through, and the check is skipped entirely if bathymetry hasn't been set up yet.

Base branch is `manish/standalone-boundary-class` (not `main`), since that's the branch this work was branched from and depends on.

## Test plan

- [x] `pytest tests/test_expt_class.py tests/test_segment_multi_boundary_domain.py -vv` — updated 2 existing tests for the new `_get_segment`/numbering signatures, added 2 new tests (list-position numbering with a mixed cardinal+interior boundary list; orientation-validation error on a deliberately-flipped interior segment).
- [x] Full suite: `pytest tests/` — 74 passed, 2 skipped (pre-existing), no failures.
- [x] `black regional_mom6/ tests/`